### PR TITLE
Improve DI wiring in UseRockLib extension method

### DIFF
--- a/RockLib.Logging.AspNetCore/AspNetExtensions.cs
+++ b/RockLib.Logging.AspNetCore/AspNetExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using RockLib.Configuration;
 
 namespace RockLib.Logging.AspNetCore
 {
@@ -16,17 +18,36 @@ namespace RockLib.Logging.AspNetCore
         /// <param name="builder">The IWebHostBuilder being extended.</param>
         /// <param name="rockLibLoggerName">The name of the RockLib logger.</param>
         /// <returns>IWebHostBuilder for chaining</returns>
-        public static IWebHostBuilder UseRockLib(this IWebHostBuilder builder, string rockLibLoggerName = null)
+        public static IWebHostBuilder UseRockLib(this IWebHostBuilder builder, string rockLibLoggerName = Logger.DefaultName)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
             builder.ConfigureServices(services =>
             {
-                services.AddSingleton<ILoggerProvider>(serviceProvider => new RockLibLoggerProvider(rockLibLoggerName));
+                services.AddSingleton<ILogger>(serviceProvider =>
+                {
+                    SetConfigRoot(serviceProvider);
+                    return LoggerFactory.GetInstance(rockLibLoggerName);
+                });
+
+                services.AddSingleton<ILoggerProvider>(serviceProvider =>
+                {
+                    SetConfigRoot(serviceProvider);
+                    return new RockLibLoggerProvider(rockLibLoggerName);
+                });
             });
 
             return builder;
+        }
+
+        private static void SetConfigRoot(IServiceProvider serviceProvider)
+        {
+            if (!Config.IsLocked)
+            {
+                var configuration = serviceProvider.GetService<IConfiguration>();
+                Config.SetRoot(configuration);
+            }
         }
     }
 }


### PR DESCRIPTION
- Ensure that Config.SetRoot is called if possible before calling LoggerFactory.GetInstance.
- Register RockLib.Logging.ILogger for DI.