### PR TITLE
Update RockLib.Logging package to version 2.0.0-alpha03

### DIFF
--- a/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
+++ b/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace RockLib.Logging.AspNetCore.Tests
                 var dummy = Config.Root;
             }
 
-            var actualLogger = LoggerFactory.GetInstance("SomeRockLibName");
+            var actualLogger = LoggerFactory.GetCached("SomeRockLibName");
 
             var serviceDescriptors = new List<ServiceDescriptor>();
 
@@ -67,7 +67,7 @@ namespace RockLib.Logging.AspNetCore.Tests
                 var dummy = Config.Root;
             }
 
-            var actualLogger = LoggerFactory.GetInstance("SomeRockLibName");
+            var actualLogger = LoggerFactory.GetCached("SomeRockLibName");
 
             var serviceDescriptors = new List<ServiceDescriptor>();
 

--- a/RockLib.Logging.AspNetCore/AspNetExtensions.cs
+++ b/RockLib.Logging.AspNetCore/AspNetExtensions.cs
@@ -21,10 +21,9 @@ namespace RockLib.Logging.AspNetCore
         /// <param name="rockLibLoggerName">The name of the RockLib logger used for logging.</param>
         /// <param name="setConfigRoot">
         /// Whether to call <see cref="Config.SetRoot(IConfiguration)"/> prior to calling
-        /// <see cref="LoggerFactory.GetInstance"/>. This value is true by default, because, by default,
-        /// the <see cref="LoggerFactory"/> uses <see cref="Config.Root"/> as the backing data source for its
-        /// <see cref="LoggerFactory.Loggers"/> property. If <see cref="LoggerFactory.Loggers"/> is set
-        /// programatically, this value can be false.
+        /// <see cref="LoggerFactory.GetCached"/>. This value is true by default, because, by default,
+        /// the <see cref="LoggerFactory"/> uses <see cref="Config.Root"/> as the backing data source.
+        /// If <see cref="LoggerFactory.SetConfiguration"/> is called directly, this value can be false.
         /// </param>
         /// <param name="bypassAspNetCoreLogging">
         /// Whether to bypass registering an <see cref="ILoggerProvider"/> with the DI system.
@@ -92,7 +91,7 @@ namespace RockLib.Logging.AspNetCore
                     Config.SetRoot(configuration);
                 }
 
-                return LoggerFactory.GetInstance(rockLibLoggerName);
+                return LoggerFactory.GetCached(rockLibLoggerName);
             });
         }
 

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="RockLib.Logging" Version="1.0.0" />
+    <PackageReference Include="RockLib.Logging" Version="2.0.0-alpha03" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This exposes configuration object factory methods and makes ILogger disposable