### PR TITLE
Add context provider feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RockLib.Logging [![Build status](https://ci.appveyor.com/api/projects/status/8fbt2w3y7svuun1s?svg=true)](https://ci.appveyor.com/project/bfriesen/rocklib-logging)
+# RockLib.Logging [![Build status](https://ci.appveyor.com/api/projects/status/y06g87sp3p3q5gb4?svg=true)](https://ci.appveyor.com/project/RockLib/rocklib-logging)
 
 *A simple logging library.*
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ class Program
 
 ### Configuration
 
-The `LoggerFactory` class retrieves its default loggers from configuration using the [RockLib.Configuration](https://github.com/RockLib/RockLib.Configuration/tree/develop/RockLib.Configuration) and [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/develop/RockLib.Configuration.ObjectFactory) packages. The easiest way add logging to your application by configuration is with an `appsettings.json` file.
+The `LoggerFactory` class retrieves its default loggers from configuration using the [RockLib.Configuration](https://github.com/RockLib/RockLib.Configuration/tree/master/RockLib.Configuration) and [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/master/RockLib.Configuration.ObjectFactory) packages. The easiest way add logging to your application by configuration is with an `appsettings.json` file.
 
 *This is a simple configuration defining a single logger with a single log provider.*
 

--- a/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
+++ b/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using RockLib.Configuration;
+using RockLib.Configuration.ObjectFactory;
 using Xunit;
 
 namespace RockLib.Logging.AspNetCore.Tests
@@ -84,7 +85,7 @@ namespace RockLib.Logging.AspNetCore.Tests
                 ServiceCollection = servicesCollectionMock.Object
             };
 
-            fakeBuilder.UseRockLibLogging("SomeRockLibName", bypassAspNetCoreLogging:true);
+            fakeBuilder.UseRockLibLogging("SomeRockLibName", bypassAspNetCoreLogging: true);
 
             servicesCollectionMock.Verify(lfm => lfm.Add(It.IsAny<ServiceDescriptor>()), Times.Once);
 
@@ -173,6 +174,152 @@ namespace RockLib.Logging.AspNetCore.Tests
             logger.Should().BeSameAs(actualLogger);
         }
 
+        [Fact]
+        public void DefaultTypesFunctionsProperly()
+        {
+            if (!Config.IsLocked)
+            {
+                var dummy = Config.Root;
+            }
+
+            var defaultTypes = new DefaultTypes
+            {
+                { typeof(ILogger), typeof(TestLogger) },
+                { typeof(ITestDependency), typeof(TestDependencyB) }
+            };
+
+            var fakeBuilder = new FakeWebHostBuilder()
+            {
+                ServiceCollection = new ServiceCollection()
+            };
+
+            fakeBuilder.UseRockLibLogging("TestLogger1", defaultTypes: defaultTypes, reloadOnConfigChange: false, bypassAspNetCoreLogging: true);
+
+            var logger = fakeBuilder.ServiceCollection[0].ImplementationFactory.Invoke(null);
+            logger.Should().BeOfType<TestLogger>();
+
+            var testLogger = (TestLogger)logger;
+            testLogger.Dependency.Should().BeOfType<TestDependencyB>();
+        }
+
+        [Fact]
+        public void ValueConvertersFunctionsProperly()
+        {
+            if (!Config.IsLocked)
+            {
+                var dummy = Config.Root;
+            }
+
+            var defaultTypes = new DefaultTypes
+            {
+                { typeof(ILogger), typeof(TestLogger) }
+            };
+
+            Point ParsePoint(string value)
+            {
+                var split = value.Split(',');
+                return new Point(int.Parse(split[0]), int.Parse(split[1]));
+            }
+            var valueConverters = new ValueConverters
+            {
+                { typeof(Point), ParsePoint }
+            };
+
+            var fakeBuilder = new FakeWebHostBuilder()
+            {
+                ServiceCollection = new ServiceCollection()
+            };
+
+            fakeBuilder.UseRockLibLogging("TestLogger2", defaultTypes: defaultTypes, valueConverters: valueConverters, reloadOnConfigChange: false, bypassAspNetCoreLogging: true);
+
+            var logger = fakeBuilder.ServiceCollection[0].ImplementationFactory.Invoke(null);
+            logger.Should().BeOfType<TestLogger>();
+
+            var testLogger = (TestLogger)logger;
+            testLogger.Location.X.Should().Be(2);
+            testLogger.Location.Y.Should().Be(3);
+        }
+
+        [Fact]
+        public void ResolverFunctionsProperly()
+        {
+            if (!Config.IsLocked)
+            {
+                var dummy = Config.Root;
+            }
+
+            var dependency = new TestDependencyA();
+            var resolver = new Resolver(t => dependency, t => t == typeof(ITestDependency));
+
+            var defaultTypes = new DefaultTypes
+            {
+                { typeof(ILogger), typeof(TestLogger) }
+            };
+
+            var fakeBuilder = new FakeWebHostBuilder()
+            {
+                ServiceCollection = new ServiceCollection()
+            };
+
+            fakeBuilder.UseRockLibLogging("TestLogger3", defaultTypes: defaultTypes, resolver: resolver, reloadOnConfigChange: false, bypassAspNetCoreLogging: true);
+
+            var logger = fakeBuilder.ServiceCollection[0].ImplementationFactory.Invoke(null);
+            logger.Should().BeOfType<TestLogger>();
+
+            var testLogger = (TestLogger)logger;
+            testLogger.Dependency.Should().BeSameAs(dependency);
+        }
+
+        [Fact]
+        public void ReloadOnConfigChangeTrueFunctionsProperly()
+        {
+            if (!Config.IsLocked)
+            {
+                var dummy = Config.Root;
+            }
+
+            var defaultTypes = new DefaultTypes
+            {
+                { typeof(ILogger), typeof(TestLogger) },
+                { typeof(ITestDependency), typeof(TestDependencyB) }
+            };
+
+            var fakeBuilder = new FakeWebHostBuilder()
+            {
+                ServiceCollection = new ServiceCollection()
+            };
+
+            fakeBuilder.UseRockLibLogging("TestLogger4", defaultTypes: defaultTypes, reloadOnConfigChange: true, bypassAspNetCoreLogging: true);
+
+            var logger = fakeBuilder.ServiceCollection[0].ImplementationFactory.Invoke(null);
+            logger.Should().BeAssignableTo<ConfigReloadingProxy<ILogger>>();
+        }
+
+        [Fact]
+        public void ReloadOnConfigChangeFalseFunctionsProperly()
+        {
+            if (!Config.IsLocked)
+            {
+                var dummy = Config.Root;
+            }
+
+            var defaultTypes = new DefaultTypes
+            {
+                { typeof(ILogger), typeof(TestLogger) },
+                { typeof(ITestDependency), typeof(TestDependencyB) }
+            };
+
+            var fakeBuilder = new FakeWebHostBuilder()
+            {
+                ServiceCollection = new ServiceCollection()
+            };
+
+            fakeBuilder.UseRockLibLogging("TestLogger5", defaultTypes: defaultTypes, reloadOnConfigChange: false, bypassAspNetCoreLogging: true);
+
+            var logger = fakeBuilder.ServiceCollection[0].ImplementationFactory.Invoke(null);
+            logger.Should().BeOfType<TestLogger>();
+        }
+
         private class FakeWebHostBuilder : IWebHostBuilder
         {
             public IServiceCollection ServiceCollection { get; set; }
@@ -209,6 +356,55 @@ namespace RockLib.Logging.AspNetCore.Tests
                 throw new NotImplementedException();
             }
             #endregion
+        }
+
+        public class TestLogger : ILogger
+        {
+            public TestLogger(Point location = default(Point), ITestDependency dependency = null)
+            {
+                Name = nameof(TestLogger);
+                Location = location;
+                Dependency = dependency;
+            }
+
+            public Point Location { get; }
+            public ITestDependency Dependency { get; }
+
+            public string Name { get; }
+            public bool IsDisabled { get; }
+            public LogLevel Level { get; }
+            public IReadOnlyCollection<ILogProvider> Providers { get; }
+
+            public void Log(LogEntry logEntry, string callerMemberName = null, string callerFilePath = null, int callerLineNumber = 0)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dispose() { }
+        }
+
+        public struct Point
+        {
+            public Point(int x, int y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public int X { get; }
+
+            public int Y { get; }
+        }
+
+        public interface ITestDependency
+        {
+        }
+
+        public class TestDependencyA : ITestDependency
+        {
+        }
+        public class TestDependencyB : ITestDependency
+        {
         }
     }
 }

--- a/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
+++ b/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace RockLib.Logging.AspNetCore.Tests
                 var dummy = Config.Root;
             }
 
-            var actualLogger = LoggerFactory.GetInstance("SomeRockLibName");
+            var actualLogger = LoggerFactory.GetCached("SomeRockLibName");
 
             var serviceDescriptors = new List<ServiceDescriptor>();
 
@@ -67,7 +67,7 @@ namespace RockLib.Logging.AspNetCore.Tests
                 var dummy = Config.Root;
             }
 
-            var actualLogger = LoggerFactory.GetInstance("SomeRockLibName");
+            var actualLogger = LoggerFactory.GetCached("SomeRockLibName");
 
             var serviceDescriptors = new List<ServiceDescriptor>();
 

--- a/RockLib.Logging.AspNetCore.Tests/RockLib.Logging.AspNetCore.Tests.csproj
+++ b/RockLib.Logging.AspNetCore.Tests/RockLib.Logging.AspNetCore.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/RockLib.Logging.AspNetCore.Tests/appsettings.json
+++ b/RockLib.Logging.AspNetCore.Tests/appsettings.json
@@ -1,7 +1,31 @@
 ﻿{
-  "rocklib.logging": {
-    "Name": "SomeRockLibName", 
-    "Level": "Debug",
-    "Providers": { "type": "RockLib.Logging.ConsoleLogProvider, RockLib.Logging" }
-  }
+  "rocklib.logging": [
+    {
+      "Name": "SomeRockLibName",
+      "Level": "Debug",
+      "Providers": { "type": "RockLib.Logging.ConsoleLogProvider, RockLib.Logging" }
+    },
+    {
+      "Name": "TestLogger1",
+      "Level": "Debug",
+      "Dependency": { "SomeValue": "So Not Null" }
+    },
+    {
+      "Name": "TestLogger2",
+      "Level": "Debug",
+      "Location": "2,3"
+    },
+    {
+      "Name": "TestLogger3",
+      "Level": "Debug"
+    },
+    {
+      "Name": "TestLogger4",
+      "Level": "Debug"
+    },
+    {
+      "Name": "TestLogger5",
+      "Level": "Debug"
+    }
+  ]
 }

--- a/RockLib.Logging.AspNetCore.appveyor.yml
+++ b/RockLib.Logging.AspNetCore.appveyor.yml
@@ -50,6 +50,18 @@ before_build:
         $package_release_notes_node.InnerText = $commit_message
     }
 
+    function Update-Package-Description ($csproj)
+    {
+        $commit_id = "$Env:appveyor_repo_commit"
+        $project_url = $csproj.SelectSingleNode("/Project/PropertyGroup/PackageProjectUrl").InnerText
+        $commit_url = "$project_url/tree/$commit_id"
+
+        $package_description_node = $csproj.SelectSingleNode("/Project/PropertyGroup/Description")
+        $original_description = $package_description_node.InnerText
+
+        $package_description_node.InnerText = "$original_description`n`nThis package was built from the source code at $commit_url"
+    }
+
     function Synchronize-AppVeyor-And-Csproj-Versions ($csproj)
     {
         $csproj_build_version = Get-Csproj-Build-Version $csproj
@@ -74,6 +86,7 @@ before_build:
     $csproj = [xml](Get-Content $csproj_path)
 
     Update-Package-Release-Notes $csproj
+    Update-Package-Description $csproj
     Synchronize-AppVeyor-And-Csproj-Versions $csproj
     Set-Csproj-Build-Version-Variable $csproj
 

--- a/RockLib.Logging.AspNetCore.appveyor.yml
+++ b/RockLib.Logging.AspNetCore.appveyor.yml
@@ -85,20 +85,20 @@ build:
   project: RockLib.Logging.AspNetCore.sln
   verbosity: minimal
 artifacts:
-- path: '**/RockLib.Logging.AspNetCore.*.nupkg'
+- path: '**/$(csproj_build_version).nupkg'
 deploy:
 - provider: GitHub
   tag: $(appveyor_repo_tag_name)
   release: $(appveyor_repo_commit_message)
   description: $(appveyor_repo_commit_message_extended)
   auth_token:
-    secure: yjDw1QLeuxM3Wvq9ZEJIB8JaEK/L2e7MhwrKicm3/SBh0FwbAEb3Fpg82h0fFALU
+    secure: Q0CeN+jtFR19qjt5S2E9/UXgGJvWCISZnuShN4FM37yzDR4CLcM3MNBTJd1ZXqEw
   on:
     appveyor_repo_tag: true
     appveyor_repo_tag_name: $(csproj_build_version)
 - provider: NuGet
   api_key:
-    secure: cWRnVOIg+HzwFkVkKWFBMbkSC0753NI/LCcxQErp8ulvVQAFCIbH4Kml/XnpQiVM
+    secure: pcCgLFHRqhhCdy1SlRcWXAqEMCfI6c5ZbHj0dqho2JNpT7I+h6dpoN6wTTqfrMnV
   on:
     appveyor_repo_tag: true
     appveyor_repo_tag_name: $(csproj_build_version)

--- a/RockLib.Logging.AspNetCore/AspNetExtensions.cs
+++ b/RockLib.Logging.AspNetCore/AspNetExtensions.cs
@@ -21,10 +21,9 @@ namespace RockLib.Logging.AspNetCore
         /// <param name="rockLibLoggerName">The name of the RockLib logger used for logging.</param>
         /// <param name="setConfigRoot">
         /// Whether to call <see cref="Config.SetRoot(IConfiguration)"/> prior to calling
-        /// <see cref="LoggerFactory.GetInstance"/>. This value is true by default, because, by default,
-        /// the <see cref="LoggerFactory"/> uses <see cref="Config.Root"/> as the backing data source for its
-        /// <see cref="LoggerFactory.Loggers"/> property. If <see cref="LoggerFactory.Loggers"/> is set
-        /// programatically, this value can be false.
+        /// <see cref="LoggerFactory.GetCached"/>. This value is true by default, because, by default,
+        /// the <see cref="LoggerFactory"/> uses <see cref="Config.Root"/> as the backing data source.
+        /// If <see cref="LoggerFactory.SetConfiguration"/> is called directly, this value can be false.
         /// </param>
         /// <param name="bypassAspNetCoreLogging">
         /// Whether to bypass registering an <see cref="ILoggerProvider"/> with the DI system.
@@ -92,7 +91,7 @@ namespace RockLib.Logging.AspNetCore
                     Config.SetRoot(configuration);
                 }
 
-                return LoggerFactory.GetInstance(rockLibLoggerName);
+                return LoggerFactory.GetCached(rockLibLoggerName);
             });
         }
 

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging.AspNetCore</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>Extensions to create hooks into Microsoft.Extensions.Logging</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Logging/blob/master/LICENSE.md</PackageLicenseUrl>
     <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>RockLib Logging Logger Extensions</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="RockLib.Logging" Version="1.0.0" />
+    <PackageReference Include="RockLib.Logging" Version="2.0.0-alpha03" />
   </ItemGroup>
 
 </Project>

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging.AspNetCore</PackageId>
-    <PackageVersion>1.0.1</PackageVersion>
+    <PackageVersion>2.0.0-alpha01</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>Extensions to create hooks into Microsoft.Extensions.Logging</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Logging/blob/master/LICENSE.md</PackageLicenseUrl>
     <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>RockLib Logging Logger Extensions</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/RockLib.Logging.AspNetCore/RockLibLogger.cs
+++ b/RockLib.Logging.AspNetCore/RockLibLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,7 +7,7 @@ namespace RockLib.Logging.AspNetCore
 {
     internal class RockLibLogger : Microsoft.Extensions.Logging.ILogger
     {
-        private readonly Lazy<Stack<object>> _scope = new Lazy<Stack<object>>(() => new Stack<object>());
+        private readonly Lazy<ConcurrentStack<object>> _scope = new Lazy<ConcurrentStack<object>>(() => new ConcurrentStack<object>());
 
         public RockLibLogger(ILogger logger, string categoryName)
         {
@@ -100,9 +101,9 @@ namespace RockLib.Logging.AspNetCore
 
         private class DisposeScope : IDisposable
         {
-            private readonly Stack<object> _scope;
-            public DisposeScope(Stack<object> scope) => _scope = scope;
-            public void Dispose() => _scope.Pop();
+            private readonly ConcurrentStack<object> _scope;
+            public DisposeScope(ConcurrentStack<object> scope) => _scope = scope;
+            public void Dispose() => _scope.TryPop(out var throwaway);
         }
     }
 }

--- a/RockLib.Logging.Tests/ArgumentSadPathTests.cs
+++ b/RockLib.Logging.Tests/ArgumentSadPathTests.cs
@@ -59,9 +59,9 @@ namespace RockLib.Logging.Tests
         public class LoggerFactory_
         {
             [Fact]
-            public void CallingSetLoggersWithNullLoggersThrowsArgumentNullException()
+            public void CallingSetConfigurationWithNullConfigurationThrowsArgumentNullException()
             {
-                Assert.Throws<ArgumentNullException>(() => LoggerFactory.SetLoggers(null));
+                Assert.Throws<ArgumentNullException>(() => LoggerFactory.SetConfiguration(null));
             }
         }
 

--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -492,10 +492,13 @@ namespace RockLib.Logging.Tests
             public bool IsDisabled { get; }
             public LogLevel Level { get; }
             public IReadOnlyCollection<ILogProvider> Providers { get; }
+
             public void Log(LogEntry logEntry, string callerMemberName = null, string callerFilePath = null, int callerLineNumber = 0)
             {
                 throw new NotImplementedException();
             }
+
+            public void Dispose() { }
         }
 
         private struct Point

--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -492,6 +492,8 @@ namespace RockLib.Logging.Tests
             public bool IsDisabled { get; }
             public LogLevel Level { get; }
             public IReadOnlyCollection<ILogProvider> Providers { get; }
+            public IReadOnlyCollection<IContextProvider> ContextProviders { get; }
+
             public event EventHandler<ErrorEventArgs> Error;
 
             public void Log(LogEntry logEntry, string callerMemberName = null, string callerFilePath = null, int callerLineNumber = 0)

--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -492,6 +492,7 @@ namespace RockLib.Logging.Tests
             public bool IsDisabled { get; }
             public LogLevel Level { get; }
             public IReadOnlyCollection<ILogProvider> Providers { get; }
+            public event EventHandler<ErrorEventArgs> Error;
 
             public void Log(LogEntry logEntry, string callerMemberName = null, string callerFilePath = null, int callerLineNumber = 0)
             {

--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -15,32 +15,8 @@ namespace RockLib.Logging.Tests
 {
     public class LoggerFactoryTests
     {
-        [Theory]
-        [InlineData(Logger.DefaultName, typeof(FooLogProvider))]
-        [InlineData("bar", typeof(BarLogProvider))]
-        public void CreateLoggerWorksWithListOfLoggers(string name, Type expectedLogProviderType)
-        {
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>()
-                {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
-                    ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
-                })
-                .Build()
-                .GetSection("rocklib.logging");
-
-            var logger = config.CreateLogger(name);
-
-            logger.Name.Should().Be(name);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(expectedLogProviderType);
-
-            config.CreateLogger(name).Should().NotBeSameAs(logger);
-        }
-
         [Fact]
-        public void CreateLoggerWorksWithSingleUnnamedLogger()
+        public void LegacyConfigurationFormatIsSupported()
         {
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -53,8 +29,52 @@ namespace RockLib.Logging.Tests
             var logger = config.CreateLogger();
 
             logger.Name.Should().Be(Logger.DefaultName);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
+
+            config.CreateLogger().Should().NotBeSameAs(logger);
+        }
+
+        [Theory]
+        [InlineData(Logger.DefaultName, typeof(FooLogProvider))]
+        [InlineData("bar", typeof(BarLogProvider))]
+        public void CreateLoggerWorksWithListOfLoggers(string name, Type expectedLogProviderType)
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:name"] = "bar",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
+
+            var logger = config.CreateLogger(name);
+
+            logger.Name.Should().Be(name);
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(expectedLogProviderType);
+
+            config.CreateLogger(name).Should().NotBeSameAs(logger);
+        }
+
+        [Fact]
+        public void CreateLoggerWorksWithSingleUnnamedLogger()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
+
+            var logger = config.CreateLogger();
+
+            logger.Name.Should().Be(Logger.DefaultName);
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
             config.CreateLogger().Should().NotBeSameAs(logger);
         }
@@ -66,7 +86,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -74,8 +94,8 @@ namespace RockLib.Logging.Tests
             var logger = config.CreateLogger("bar");
 
             logger.Name.Should().Be("bar");
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(BarLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(BarLogProvider));
 
             config.CreateLogger("bar").Should().NotBeSameAs(logger);
         }
@@ -86,9 +106,9 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                     ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -106,7 +126,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -125,9 +145,9 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                     ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -135,8 +155,8 @@ namespace RockLib.Logging.Tests
             var logger = config.GetCachedLogger(name);
 
             logger.Name.Should().Be(name);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(expectedLogProviderType);
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(expectedLogProviderType);
 
             config.GetCachedLogger(name).Should().BeSameAs(logger);
         }
@@ -147,7 +167,7 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -155,8 +175,8 @@ namespace RockLib.Logging.Tests
             var logger = config.GetCachedLogger();
 
             logger.Name.Should().Be(Logger.DefaultName);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
             config.GetCachedLogger().Should().BeSameAs(logger);
         }
@@ -168,7 +188,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -176,8 +196,8 @@ namespace RockLib.Logging.Tests
             var logger = config.GetCachedLogger("bar");
 
             logger.Name.Should().Be("bar");
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(BarLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(BarLogProvider));
 
             config.GetCachedLogger("bar").Should().BeSameAs(logger);
         }
@@ -188,9 +208,9 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                     ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -208,7 +228,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -253,7 +273,7 @@ namespace RockLib.Logging.Tests
             var config = new InterceptingConfigurationSection(new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("RockLib.Logging"));
@@ -267,8 +287,8 @@ namespace RockLib.Logging.Tests
                 config.Usages.Should().BeGreaterThan(0);
 
                 logger.Name.Should().Be(Logger.DefaultName);
-                logger.Providers.Count.Should().Be(1);
-                logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+                logger.LogProviders.Count.Should().Be(1);
+                logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
                 LoggerFactory.Create().Should().NotBeSameAs(logger);
             }
@@ -290,7 +310,7 @@ namespace RockLib.Logging.Tests
             var config = new InterceptingConfigurationSection(new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("RockLib.Logging"));
@@ -304,8 +324,8 @@ namespace RockLib.Logging.Tests
                 config.Usages.Should().BeGreaterThan(0);
 
                 logger.Name.Should().Be(Logger.DefaultName);
-                logger.Providers.Count.Should().Be(1);
-                logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+                logger.LogProviders.Count.Should().Be(1);
+                logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
                 LoggerFactory.GetCached().Should().BeSameAs(logger);
             }
@@ -491,7 +511,7 @@ namespace RockLib.Logging.Tests
             public string Name { get; }
             public bool IsDisabled { get; }
             public LogLevel Level { get; }
-            public IReadOnlyCollection<ILogProvider> Providers { get; }
+            public IReadOnlyCollection<ILogProvider> LogProviders { get; }
             public IReadOnlyCollection<IContextProvider> ContextProviders { get; }
 
             public event EventHandler<ErrorEventArgs> Error;

--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -1,18 +1,135 @@
 ﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using RockLib.Configuration;
 using RockLib.Immutable;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace RockLib.Logging.Tests
 {
     public class LoggerFactoryTests
     {
+        [Theory]
+        [InlineData(Logger.DefaultName, typeof(FooLogProvider))]
+        [InlineData("bar", typeof(BarLogProvider))]
+        public void CreateFromConfigWorksWithListOfLoggers(string name, Type expectedLogProviderType)
+        {
+            ResetConfig();
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:name"] = "bar",
+                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build();
+
+            Config.SetRoot(config);
+
+            var logger = LoggerFactory.CreateFromConfig(name);
+
+            logger.Name.Should().Be(name);
+            logger.Providers.Count.Should().Be(1);
+            logger.Providers.First().Should().BeOfType(expectedLogProviderType);
+        }
+
+        [Fact]
+        public void CreateFromConfigWorksWithSingleUnnamedLogger()
+        {
+            ResetConfig();
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                })
+                .Build();
+
+            Config.SetRoot(config);
+
+            var logger = LoggerFactory.CreateFromConfig();
+
+            logger.Name.Should().Be(Logger.DefaultName);
+            logger.Providers.Count.Should().Be(1);
+            logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+        }
+
+        [Fact]
+        public void CreateFromConfigWorksWithSingleNamedLogger()
+        {
+            ResetConfig();
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:name"] = "bar",
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build();
+
+            Config.SetRoot(config);
+
+            var logger = LoggerFactory.CreateFromConfig("bar");
+
+            logger.Name.Should().Be("bar");
+            logger.Providers.Count.Should().Be(1);
+            logger.Providers.First().Should().BeOfType(typeof(BarLogProvider));
+        }
+
+        [Fact]
+        public void CreateFromConfigThrowsWhenNotFoundInListOfLoggers()
+        {
+            ResetConfig();
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:name"] = "bar",
+                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build();
+
+            Config.SetRoot(config);
+
+            var name = "baz";
+            Action action = () =>  LoggerFactory.CreateFromConfig(name);
+
+            action.ShouldThrow<KeyNotFoundException>().WithMessage($"The {LoggerFactory.SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
+        }
+
+        [Fact]
+        public void CreateFromConfigThrowsWhenNotFoundInSingleLogger()
+        {
+            ResetConfig();
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:name"] = "bar",
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build();
+
+            Config.SetRoot(config);
+
+            var name = "baz";
+            Action action = () => LoggerFactory.CreateFromConfig(name);
+
+            action.ShouldThrow<KeyNotFoundException>().WithMessage($"The {LoggerFactory.SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
+        }
+
         [Fact]
         public void DefaultValueOfLoggersComesFromConfig()
         {
+            ResetConfig();
             ResetLoggerFactoryLoggers();
 
             LoggerFactory.Loggers.Count.Should().Be(1);
@@ -125,5 +242,28 @@ namespace RockLib.Logging.Tests
             var lookup = (ConcurrentDictionary<string, Logger>)lookupField.GetValue(null);
             lookup.Clear();
         }
+
+        private void ResetConfig()
+        {
+            var rootField = typeof(Config).GetField("_root", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var root = (Semimutable<IConfiguration>)rootField.GetValue(null);
+            root.GetUnlockValueMethod().Invoke(root, null);
+            root.ResetValue();
+        }
+    }
+
+    public class FooLogProvider : ILogProvider
+    {
+        public TimeSpan Timeout => throw new NotImplementedException();
+        public LogLevel Level => throw new NotImplementedException();
+        public Task WriteAsync(LogEntry logEntry, CancellationToken cancellationToken) => throw new NotImplementedException();
+    }
+
+    public class BarLogProvider : ILogProvider
+    {
+        public TimeSpan Timeout => throw new NotImplementedException();
+        public LogLevel Level => throw new NotImplementedException();
+        public Task WriteAsync(LogEntry logEntry, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }

--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -1,9 +1,8 @@
 ﻿using FluentAssertions;
 using Microsoft.Extensions.Configuration;
-using RockLib.Configuration;
+using Microsoft.Extensions.Primitives;
 using RockLib.Immutable;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -18,10 +17,8 @@ namespace RockLib.Logging.Tests
         [Theory]
         [InlineData(Logger.DefaultName, typeof(FooLogProvider))]
         [InlineData("bar", typeof(BarLogProvider))]
-        public void CreateFromConfigWorksWithListOfLoggers(string name, Type expectedLogProviderType)
+        public void CreateLoggerWorksWithListOfLoggers(string name, Type expectedLogProviderType)
         {
-            ResetConfig();
-
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
@@ -29,65 +26,62 @@ namespace RockLib.Logging.Tests
                     ["rocklib.logging:1:name"] = "bar",
                     ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
-                .Build();
+                .Build()
+                .GetSection("rocklib.logging");
 
-            Config.SetRoot(config);
-
-            var logger = LoggerFactory.CreateFromConfig(name);
+            var logger = config.CreateLogger(name);
 
             logger.Name.Should().Be(name);
             logger.Providers.Count.Should().Be(1);
             logger.Providers.First().Should().BeOfType(expectedLogProviderType);
+
+            config.CreateLogger(name).Should().NotBeSameAs(logger);
         }
 
         [Fact]
-        public void CreateFromConfigWorksWithSingleUnnamedLogger()
+        public void CreateLoggerWorksWithSingleUnnamedLogger()
         {
-            ResetConfig();
-
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                 })
-                .Build();
+                .Build()
+                .GetSection("rocklib.logging");
 
-            Config.SetRoot(config);
-
-            var logger = LoggerFactory.CreateFromConfig();
+            var logger = config.CreateLogger();
 
             logger.Name.Should().Be(Logger.DefaultName);
             logger.Providers.Count.Should().Be(1);
             logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+
+            config.CreateLogger().Should().NotBeSameAs(logger);
         }
 
         [Fact]
-        public void CreateFromConfigWorksWithSingleNamedLogger()
+        public void CreateLoggerWorksWithSingleNamedLogger()
         {
-            ResetConfig();
-
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
                     ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
-                .Build();
+                .Build()
+                .GetSection("rocklib.logging");
 
-            Config.SetRoot(config);
-
-            var logger = LoggerFactory.CreateFromConfig("bar");
+            var logger = config.CreateLogger("bar");
 
             logger.Name.Should().Be("bar");
             logger.Providers.Count.Should().Be(1);
             logger.Providers.First().Should().BeOfType(typeof(BarLogProvider));
+
+            config.CreateLogger("bar").Should().NotBeSameAs(logger);
         }
 
         [Fact]
-        public void CreateFromConfigThrowsWhenNotFoundInListOfLoggers()
+        public void CreateLoggerThrowsWhenNotFoundInListOfLoggers()
         {
-            ResetConfig();
-
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
@@ -95,161 +89,285 @@ namespace RockLib.Logging.Tests
                     ["rocklib.logging:1:name"] = "bar",
                     ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
-                .Build();
-
-            Config.SetRoot(config);
+                .Build()
+                .GetSection("rocklib.logging");
 
             var name = "baz";
-            Action action = () =>  LoggerFactory.CreateFromConfig(name);
+            Action action = () =>  config.CreateLogger(name);
 
-            action.ShouldThrow<KeyNotFoundException>().WithMessage($"The {LoggerFactory.SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
+            action.ShouldThrow<KeyNotFoundException>().WithMessage($"No loggers were found matching the name '{name}'.");
         }
 
         [Fact]
-        public void CreateFromConfigThrowsWhenNotFoundInSingleLogger()
+        public void CreateLoggerThrowsWhenNotFoundInSingleLogger()
         {
-            ResetConfig();
-
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
                     ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
-                .Build();
-
-            Config.SetRoot(config);
+                .Build()
+                .GetSection("rocklib.logging");
 
             var name = "baz";
-            Action action = () => LoggerFactory.CreateFromConfig(name);
+            Action action = () => config.CreateLogger(name);
 
-            action.ShouldThrow<KeyNotFoundException>().WithMessage($"The {LoggerFactory.SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
+            action.ShouldThrow<KeyNotFoundException>().WithMessage($"No loggers were found matching the name '{name}'.");
         }
 
-        [Fact]
-        public void DefaultValueOfLoggersComesFromConfig()
+        [Theory]
+        [InlineData(Logger.DefaultName, typeof(FooLogProvider))]
+        [InlineData("bar", typeof(BarLogProvider))]
+        public void GetCachedLoggerWorksWithListOfLoggers(string name, Type expectedLogProviderType)
         {
-            ResetConfig();
-            ResetLoggerFactoryLoggers();
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:name"] = "bar",
+                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
 
-            LoggerFactory.Loggers.Count.Should().Be(1);
-            var logger = LoggerFactory.Loggers.First();
-            logger.Name.Should().Be("TestLogger");
-            logger.Level.Should().Be(LogLevel.Info);
+            var logger = config.GetCachedLogger(name);
+
+            logger.Name.Should().Be(name);
             logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType<ConsoleLogProvider>();
-            var provider = (ConsoleLogProvider)logger.Providers.First();
-            provider.Level.Should().Be(LogLevel.Warn);
-            provider.Formatter.Should().BeOfType<TemplateLogFormatter>();
-            var formatter = (TemplateLogFormatter)provider.Formatter;
-            formatter.Template.Should().Be("foo bar");
+            logger.Providers.First().Should().BeOfType(expectedLogProviderType);
+
+            config.GetCachedLogger(name).Should().BeSameAs(logger);
         }
 
         [Fact]
-        public void CanSpecifyLoggersProgrammatically()
+        public void GetCachedLoggerWorksWithSingleUnnamedLogger()
         {
-            ResetLoggerFactoryLoggers();
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
 
-            LoggerFactory.SetLoggers(new []
+            var logger = config.GetCachedLogger();
+
+            logger.Name.Should().Be(Logger.DefaultName);
+            logger.Providers.Count.Should().Be(1);
+            logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+
+            config.GetCachedLogger().Should().BeSameAs(logger);
+        }
+
+        [Fact]
+        public void GetCachedLoggerWorksWithSingleNamedLogger()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:name"] = "bar",
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
+
+            var logger = config.GetCachedLogger("bar");
+
+            logger.Name.Should().Be("bar");
+            logger.Providers.Count.Should().Be(1);
+            logger.Providers.First().Should().BeOfType(typeof(BarLogProvider));
+
+            config.GetCachedLogger("bar").Should().BeSameAs(logger);
+        }
+
+        [Fact]
+        public void GetCachedLoggerThrowsWhenNotFoundInListOfLoggers()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:name"] = "bar",
+                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
+
+            var name = "baz";
+            Action action = () => config.GetCachedLogger(name);
+
+            action.ShouldThrow<KeyNotFoundException>().WithMessage($"No loggers were found matching the name '{name}'.");
+        }
+
+        [Fact]
+        public void GetCachedLoggerThrowsWhenNotFoundInSingleLogger()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:name"] = "bar",
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
+
+            var name = "baz";
+            Action action = () => config.GetCachedLogger(name);
+
+            action.ShouldThrow<KeyNotFoundException>().WithMessage($"No loggers were found matching the name '{name}'.");
+        }
+
+        [Fact]
+        public void SetConfigurationSetsTheConfigurationProperty()
+        {
+            var configurationField = GetSemimutableConfigurationField();
+
+            var existingConfig = configurationField.Value;
+            configurationField.GetUnlockValueMethod().Invoke(configurationField, null);
+
+            var config = new ConfigurationBuilder().Build();
+
+            LoggerFactory.SetConfiguration(config);
+
+            try
             {
-                new Logger("foo"),
-                new Logger("bar"),
-                new Logger("baz")
-            });
-
-            LoggerFactory.Loggers.Count.Should().Be(3);
-
-            LoggerFactory.Loggers.First().Name.Should().Be("foo");
-            LoggerFactory.Loggers.Skip(1).First().Name.Should().Be("bar");
-            LoggerFactory.Loggers.Skip(2).First().Name.Should().Be("baz");
+                LoggerFactory.Configuration.Should().BeSameAs(config);
+            }
+            finally
+            {
+                configurationField.GetUnlockValueMethod().Invoke(configurationField, null);
+                LoggerFactory.SetConfiguration(existingConfig);
+            }
         }
 
         [Fact]
-        public void GetInstanceWithNameReturnsTheLoggerWithTheSameName()
+        public void CreateCallsCreateLoggerWithConfigurationProperty()
         {
-            ResetLoggerFactoryLoggers();
+            var configurationField = GetSemimutableConfigurationField();
 
-            Logger expectedLogger = new Logger("foo");
+            var existingConfig = configurationField.Value;
+            configurationField.GetUnlockValueMethod().Invoke(configurationField, null);
 
-            LoggerFactory.SetLoggers(new[] { expectedLogger });
+            var config = new InterceptingConfigurationSection(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("RockLib.Logging"));
 
-            var logger = LoggerFactory.GetInstance("foo");
+            LoggerFactory.SetConfiguration(config);
 
-            logger.Should().BeSameAs(expectedLogger);
+            try
+            {
+                var logger = LoggerFactory.Create();
+
+                config.Usages.Should().BeGreaterThan(0);
+
+                logger.Name.Should().Be(Logger.DefaultName);
+                logger.Providers.Count.Should().Be(1);
+                logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+
+                LoggerFactory.Create().Should().NotBeSameAs(logger);
+            }
+            finally
+            {
+                configurationField.GetUnlockValueMethod().Invoke(configurationField, null);
+                LoggerFactory.SetConfiguration(existingConfig);
+            }
         }
 
         [Fact]
-        public void GetInstanceWithNameReturnsTheLoggerWithTheSameCaseInsensitiveName()
+        public void GetCachedCallsGetCachedLoggerWithConfigurationProperty()
         {
-            ResetLoggerFactoryLoggers();
+            var configurationField = GetSemimutableConfigurationField();
 
-            Logger expectedLogger = new Logger("foo");
+            var existingConfig = configurationField.Value;
+            configurationField.GetUnlockValueMethod().Invoke(configurationField, null);
 
-            LoggerFactory.SetLoggers(new[] { expectedLogger });
+            var config = new InterceptingConfigurationSection(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("RockLib.Logging"));
 
-            var logger = LoggerFactory.GetInstance("FOO");
+            LoggerFactory.SetConfiguration(config);
 
-            logger.Should().BeSameAs(expectedLogger);
+            try
+            {
+                var logger = LoggerFactory.GetCached();
+
+                config.Usages.Should().BeGreaterThan(0);
+
+                logger.Name.Should().Be(Logger.DefaultName);
+                logger.Providers.Count.Should().Be(1);
+                logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+
+                LoggerFactory.GetCached().Should().BeSameAs(logger);
+            }
+            finally
+            {
+                configurationField.GetUnlockValueMethod().Invoke(configurationField, null);
+                LoggerFactory.SetConfiguration(existingConfig);
+            }
         }
 
-        [Fact]
-        public void GetInstanceWithDefaultNameReturnsTheDefaultLogger()
+        private class InterceptingConfigurationSection : IConfigurationSection
         {
-            ResetLoggerFactoryLoggers();
+            private readonly IConfigurationSection _configuration;
 
-            var expectedLogger = new Logger();
+            public InterceptingConfigurationSection(IConfigurationSection configuration)
+            {
+                _configuration = configuration;
+            }
 
-            LoggerFactory.SetLoggers(new[] { expectedLogger });
+            public int Usages { get; private set; }
 
-            var logger = LoggerFactory.GetInstance();
+            public string this[string key]
+            {
+                get { Usages++;  return _configuration[key]; }
+                set { Usages++; _configuration[key] = value; }
+            }
 
-            logger.Should().BeSameAs(expectedLogger);
+            public string Key
+            {
+                get { Usages++; return _configuration.Key; }
+            }
+
+            public string Path
+            {
+                get { Usages++; return _configuration.Path; }
+            }
+
+            public string Value
+            {
+                get { Usages++; return _configuration.Value; }
+                set { Usages++; _configuration.Value = value; }
+            }
+
+            public IEnumerable<IConfigurationSection> GetChildren()
+            {
+                Usages++; return _configuration.GetChildren();
+            }
+
+            public IChangeToken GetReloadToken()
+            {
+                Usages++; return _configuration.GetReloadToken();
+            }
+
+            public IConfigurationSection GetSection(string key)
+            {
+                Usages++; return _configuration.GetSection(key);
+            }
         }
 
-        [Fact]
-        public void GetInstanceWithNullNameReturnsTheDefaultLogger()
+        private static Semimutable<IConfiguration> GetSemimutableConfigurationField()
         {
-            ResetLoggerFactoryLoggers();
-
-            var expectedLogger = new Logger();
-
-            LoggerFactory.SetLoggers(new[] { expectedLogger });
-
-            var logger = LoggerFactory.GetInstance(null);
-
-            logger.Should().BeSameAs(expectedLogger);
-        }
-
-        [Fact]
-        public void GetInstanceWithNoMatchThrowsKeyNotFoundException()
-        {
-            ResetLoggerFactoryLoggers();
-
-            LoggerFactory.SetLoggers(new Logger[0]);
-
-            Assert.Throws<KeyNotFoundException>(() => LoggerFactory.GetInstance());
-        }
-
-        private void ResetLoggerFactoryLoggers()
-        {
-            var loggersField = typeof(LoggerFactory).GetField("_loggers", BindingFlags.NonPublic | BindingFlags.Static);
-            var lookupField = typeof(LoggerFactory).GetField("_lookup", BindingFlags.NonPublic | BindingFlags.Static);
-
-            var loggers = (Semimutable<IReadOnlyCollection<Logger>>)loggersField.GetValue(null);
-            loggers.GetUnlockValueMethod().Invoke(loggers, null);
-            loggers.ResetValue();
-
-            var lookup = (ConcurrentDictionary<string, Logger>)lookupField.GetValue(null);
-            lookup.Clear();
-        }
-
-        private void ResetConfig()
-        {
-            var rootField = typeof(Config).GetField("_root", BindingFlags.NonPublic | BindingFlags.Static);
-
-            var root = (Semimutable<IConfiguration>)rootField.GetValue(null);
-            root.GetUnlockValueMethod().Invoke(root, null);
-            root.ResetValue();
+            var field = typeof(LoggerFactory).GetField("_configuration", BindingFlags.NonPublic | BindingFlags.Static);
+            return (Semimutable<IConfiguration>)field.GetValue(null);
         }
     }
 

--- a/RockLib.Logging.Tests/LoggerTests.cs
+++ b/RockLib.Logging.Tests/LoggerTests.cs
@@ -173,7 +173,7 @@ namespace RockLib.Logging.Tests
         }
 
         [Fact]
-        public void LogAddsCallerInfoExtendedPropertyToLogEntry()
+        public void LogAddsCallerInfoToLogEntry()
         {
             var logProviders = new[]
             {
@@ -187,7 +187,7 @@ namespace RockLib.Logging.Tests
             logger.Log(logEntry);
             logger.Dispose();
 
-            logEntry.ExtendedProperties.Should().ContainKey("CallerInfo");
+            logEntry.CallerInfo.Should().NotBeNullOrWhiteSpace();
         }
 
         [Fact]

--- a/RockLib.Logging.Tests/LoggerTests.cs
+++ b/RockLib.Logging.Tests/LoggerTests.cs
@@ -29,11 +29,11 @@ namespace RockLib.Logging.Tests
         [Fact]
         public void ProvidersIsSetFromConstructor()
         {
-            var providers = new ILogProvider[0];
+            var logProviders = new ILogProvider[0];
 
-            var logger = new Logger(providers: providers);
+            var logger = new Logger(logProviders: logProviders);
 
-            logger.Providers.Should().BeSameAs(providers);
+            logger.LogProviders.Should().BeSameAs(logProviders);
         }
 
         [Fact]
@@ -57,14 +57,14 @@ namespace RockLib.Logging.Tests
         {
             var name = "foo";
             var level = LogLevel.Warn;
-            var providers = new ILogProvider[0];
+            var logProviders = new ILogProvider[0];
             var isDisabled = true;
 
-            var logger = new Logger(name, level, providers, isDisabled);
+            var logger = new Logger(name, level, logProviders, isDisabled);
 
             logger.Name.Should().Be(name);
             logger.Level.Should().Be(level);
-            logger.Providers.Should().BeSameAs(providers);
+            logger.LogProviders.Should().BeSameAs(logProviders);
             logger.IsDisabled.Should().Be(isDisabled);
             logger.IsSynchronous.Should().BeFalse();
         }
@@ -96,7 +96,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -120,7 +120,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info, isDisabled: true);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info, isDisabled: true);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -139,7 +139,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Error);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Error);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -161,7 +161,7 @@ namespace RockLib.Logging.Tests
                 auditLevelLogProvider,
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -180,7 +180,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -195,7 +195,7 @@ namespace RockLib.Logging.Tests
         {
             var logProvider = new SemaphoreDelayedLogProvider();
 
-            var logger = new Logger(providers: new[] { logProvider }, level: LogLevel.Info);
+            var logger = new Logger(logProviders: new[] { logProvider }, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -222,7 +222,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info, isSynchronous: true);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info, isSynchronous: true);
 
             var type = typeof(Logger);
             var processingThreadField = type.GetField("_processingThread", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -241,7 +241,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info, isSynchronous: true);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info, isSynchronous: true);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 

--- a/RockLib.Logging.Tests/appsettings.json
+++ b/RockLib.Logging.Tests/appsettings.json
@@ -2,7 +2,7 @@
     "rocklib.logging": {
         "Name": "TestLogger",
         "Level": "Info",
-        "Providers": {
+        "LogProviders": {
             "type": "RockLib.Logging.ConsoleLogProvider, RockLib.Logging",
             "value": {
                 "template": "foo bar",

--- a/RockLib.Logging.appveyor.yml
+++ b/RockLib.Logging.appveyor.yml
@@ -88,20 +88,20 @@ build:
   project: RockLib.Logging.sln
   verbosity: minimal
 artifacts:
-- path: '**/RockLib.Logging.*.nupkg'
+- path: '**/$(csproj_build_version).nupkg'
 deploy:
 - provider: GitHub
   tag: $(appveyor_repo_tag_name)
   release: $(appveyor_repo_commit_message)
   description: $(appveyor_repo_commit_message_extended)
   auth_token:
-    secure: yjDw1QLeuxM3Wvq9ZEJIB8JaEK/L2e7MhwrKicm3/SBh0FwbAEb3Fpg82h0fFALU
+    secure: Q0CeN+jtFR19qjt5S2E9/UXgGJvWCISZnuShN4FM37yzDR4CLcM3MNBTJd1ZXqEw
   on:
     appveyor_repo_tag: true
     appveyor_repo_tag_name: $(csproj_build_version)
 - provider: NuGet
   api_key:
-    secure: cWRnVOIg+HzwFkVkKWFBMbkSC0753NI/LCcxQErp8ulvVQAFCIbH4Kml/XnpQiVM
+    secure: pcCgLFHRqhhCdy1SlRcWXAqEMCfI6c5ZbHj0dqho2JNpT7I+h6dpoN6wTTqfrMnV
   on:
     appveyor_repo_tag: true
     appveyor_repo_tag_name: $(csproj_build_version)

--- a/RockLib.Logging.appveyor.yml
+++ b/RockLib.Logging.appveyor.yml
@@ -53,6 +53,18 @@ before_build:
         $package_release_notes_node.InnerText = $commit_message
     }
 
+    function Update-Package-Description ($csproj)
+    {
+        $commit_id = "$Env:appveyor_repo_commit"
+        $project_url = $csproj.SelectSingleNode("/Project/PropertyGroup/PackageProjectUrl").InnerText
+        $commit_url = "$project_url/tree/$commit_id"
+
+        $package_description_node = $csproj.SelectSingleNode("/Project/PropertyGroup/Description")
+        $original_description = $package_description_node.InnerText
+
+        $package_description_node.InnerText = "$original_description`n`nThis package was built from the source code at $commit_url"
+    }
+
     function Synchronize-AppVeyor-And-Csproj-Versions ($csproj)
     {
         $csproj_build_version = Get-Csproj-Build-Version $csproj
@@ -77,6 +89,7 @@ before_build:
     $csproj = [xml](Get-Content $csproj_path)
 
     Update-Package-Release-Notes $csproj
+    Update-Package-Description $csproj
     Synchronize-AppVeyor-And-Csproj-Versions $csproj
     Set-Csproj-Build-Version-Variable $csproj
 

--- a/RockLib.Logging/ErrorEventArgs.cs
+++ b/RockLib.Logging/ErrorEventArgs.cs
@@ -1,0 +1,72 @@
+﻿using System;
+
+namespace RockLib.Logging
+{
+    /// <summary>
+    /// Provides data for the <see cref="ILogger.Error"/> event.
+    /// </summary>
+    public class ErrorEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ErrorEventArgs"/> class.
+        /// </summary>
+        /// <param name="message">A message the describes the error.</param>
+        /// <param name="exception">The exception responsible for the error.</param>
+        /// <param name="logProvider">
+        /// The log provider that failed to write the log entry.
+        /// </param>
+        /// <param name="logEntry">The log entry that failed to write.</param>
+        /// <param name="failureCount">
+        /// The number of times the log provider has failed to write the log entry.
+        /// </param>
+        public ErrorEventArgs(string message, Exception exception, ILogProvider logProvider, LogEntry logEntry, int failureCount)
+        {
+            Message = message;
+            Exception = exception;
+            LogProvider = logProvider;
+            LogEntry = logEntry;
+            FailureCount = failureCount;
+        }
+
+        /// <summary>
+        /// Gets the message that describes the error.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets the exception responsible for the error.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Gets the log provider that failed to write the log entry.
+        /// </summary>
+        public ILogProvider LogProvider { get; }
+
+        /// <summary>
+        /// Gets the log entry that failed to write.
+        /// </summary>
+        public LogEntry LogEntry { get; }
+
+        /// <summary>
+        /// Gets the number of times the log provider has failed to write the log entry.
+        /// </summary>
+        public int FailureCount { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the error was a result of timing out.
+        /// </summary>
+        public bool IsTimeout => Exception == null;
+
+        /// <summary>
+        /// Gets the time that the error event occurred.
+        /// </summary>
+        public DateTime Timestamp { get; } = DateTime.Now;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the log provider should attempt to send
+        /// the log entry again.
+        /// </summary>
+        public bool ShouldRetry { get; set; }
+    }
+}

--- a/RockLib.Logging/Extensions/LoggingExtensions.cs
+++ b/RockLib.Logging/Extensions/LoggingExtensions.cs
@@ -14,6 +14,9 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="logger">The logger that performs the debug logging operation.</param>
         /// <param name="message">The log message.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -25,12 +28,16 @@ namespace RockLib.Logging
         public static void Debug(
             this ILogger logger,
             string message,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Debug, message, null, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Debug, message, null, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -39,6 +46,9 @@ namespace RockLib.Logging
         /// <param name="logger">The logger that performs the debug logging operation.</param>
         /// <param name="message">The log message.</param>
         /// <param name="exception">The <see cref="Exception"/> associated with the current logging operation.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -50,12 +60,16 @@ namespace RockLib.Logging
         public static void Debug(this ILogger logger,
             string message,
             Exception exception,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Debug, message, exception, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Debug, message, exception, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -63,6 +77,9 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="logger">The logger that performs the info logging operation.</param>
         /// <param name="message">The log message.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -74,12 +91,16 @@ namespace RockLib.Logging
         public static void Info(
             this ILogger logger,
             string message,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Info, message, null, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Info, message, null, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -88,6 +109,9 @@ namespace RockLib.Logging
         /// <param name="logger">The logger that performs the info logging operation.</param>
         /// <param name="message">The log message.</param>
         /// <param name="exception">The <see cref="Exception"/> associated with the current logging operation.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -99,12 +123,16 @@ namespace RockLib.Logging
         public static void Info(this ILogger logger,
             string message,
             Exception exception,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Info, message, exception, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Info, message, exception, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -112,6 +140,9 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="logger">The logger that performs the warn logging operation.</param>
         /// <param name="message">The log message.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -123,12 +154,16 @@ namespace RockLib.Logging
         public static void Warn(
             this ILogger logger,
             string message,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Warn, message, null, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Warn, message, null, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -137,6 +172,9 @@ namespace RockLib.Logging
         /// <param name="logger">The logger that performs the warn logging operation.</param>
         /// <param name="message">The log message.</param>
         /// <param name="exception">The <see cref="Exception"/> associated with the current logging operation.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -148,12 +186,16 @@ namespace RockLib.Logging
         public static void Warn(this ILogger logger,
             string message,
             Exception exception,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Warn, message, exception, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Warn, message, exception, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -161,6 +203,9 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="logger">The logger that performs the error logging operation.</param>
         /// <param name="message">The log message.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -172,12 +217,16 @@ namespace RockLib.Logging
         public static void Error(
             this ILogger logger,
             string message,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Error, message, null, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Error, message, null, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -186,6 +235,9 @@ namespace RockLib.Logging
         /// <param name="logger">The logger that performs the error logging operation.</param>
         /// <param name="message">The log message.</param>
         /// <param name="exception">The <see cref="Exception"/> associated with the current logging operation.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -197,12 +249,16 @@ namespace RockLib.Logging
         public static void Error(this ILogger logger,
             string message,
             Exception exception,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Error, message, exception, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Error, message, exception, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -210,6 +266,9 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="logger">The logger that performs the fatal logging operation.</param>
         /// <param name="message">The log message.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -221,12 +280,16 @@ namespace RockLib.Logging
         public static void Fatal(
             this ILogger logger,
             string message,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Fatal, message, null, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Fatal, message, null, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -235,6 +298,9 @@ namespace RockLib.Logging
         /// <param name="logger">The logger that performs the fatal logging operation.</param>
         /// <param name="message">The log message.</param>
         /// <param name="exception">The <see cref="Exception"/> associated with the current logging operation.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -246,12 +312,16 @@ namespace RockLib.Logging
         public static void Fatal(this ILogger logger,
             string message,
             Exception exception,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Fatal, message, exception, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Fatal, message, exception, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -259,6 +329,9 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="logger">The logger that performs the audit logging operation.</param>
         /// <param name="message">The log message.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -270,12 +343,16 @@ namespace RockLib.Logging
         public static void Audit(
             this ILogger logger,
             string message,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger.Log(LogLevel.Audit, message, null, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Audit, message, null, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
@@ -284,6 +361,9 @@ namespace RockLib.Logging
         /// <param name="logger">The logger that performs the audit logging operation.</param>
         /// <param name="message">The log message.</param>
         /// <param name="exception">The <see cref="Exception"/> associated with the current logging operation.</param>
+        /// <param name="correlationId">The ID used to corralate a transaction across many service calls for this log entry.</param>
+        /// <param name="businessProcessId">The business process ID.</param>
+        /// <param name="businessActivityId">The business activity ID.</param>
         /// <param name="extendedProperties">
         /// An object whose properties are added to a <see cref="LogEntry.ExtendedProperties"/> dictionary.
         /// If this object is an <see cref="IDictionary{TKey, TValue}"/> with a string key, then each of
@@ -295,16 +375,23 @@ namespace RockLib.Logging
         public static void Audit(this ILogger logger,
             string message,
             Exception exception,
+            string correlationId = null,
+            string businessProcessId = null,
+            string businessActivityId = null,
             object extendedProperties = null,
             [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = 0) =>
-            logger.Log(LogLevel.Audit, message, exception, extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
+            logger.Log(LogLevel.Audit, message, exception, correlationId, businessProcessId, businessActivityId,
+                extendedProperties, callerMemberName, callerFilePath, callerLineNumber);
 
         private static void Log(this ILogger logger,
             LogLevel level,
             string message,
             Exception exception,
+            string correlationId,
+            string businessProcessId,
+            string businessActivityId,
             object extendedProperties,
             string callerMemberName,
             string callerFilePath,
@@ -313,7 +400,12 @@ namespace RockLib.Logging
             if (logger.IsDisabled || level < logger.Level)
                 return;
 
-            var logEntry = new LogEntry(message, exception, level, extendedProperties);
+            var logEntry = new LogEntry(message, exception, level, extendedProperties)
+            {
+                CorrelationId = correlationId,
+                BusinessProcessId = businessProcessId,
+                BusinessActivityId = businessActivityId
+            };
             logger.Log(logEntry, callerMemberName, callerFilePath, callerLineNumber);
         }
     }

--- a/RockLib.Logging/IContextProvider.cs
+++ b/RockLib.Logging/IContextProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace RockLib.Logging
+{
+    /// <summary>
+    /// Defines an object that adds custom context to <see cref="LogEntry"/> objects.
+    /// </summary>
+    public interface IContextProvider
+    {
+        /// <summary>
+        /// Add custom context to the <see cref="LogEntry"/> object.
+        /// </summary>
+        /// <param name="logEntry">The log entry to add custom context to.</param>
+        void AddContext(LogEntry logEntry);
+    }
+}

--- a/RockLib.Logging/ILogger.cs
+++ b/RockLib.Logging/ILogger.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace RockLib.Logging
@@ -6,7 +7,7 @@ namespace RockLib.Logging
     /// <summary>
     /// Defines an object used for logging.
     /// </summary>
-    public interface ILogger
+    public interface ILogger : IDisposable
     {
         /// <summary>
         /// Gets the name of the logger.

--- a/RockLib.Logging/ILogger.cs
+++ b/RockLib.Logging/ILogger.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace RockLib.Logging
 {
@@ -25,6 +26,11 @@ namespace RockLib.Logging
         /// not be logged by this logger.
         /// </remarks>
         LogLevel Level { get; }
+
+        /// <summary>
+        /// Gets the collection of <see cref="ILogProvider"/> objects used by this logger.
+        /// </summary>
+        IReadOnlyCollection<ILogProvider> Providers { get; }
 
         /// <summary>
         /// Logs the specified log entry.

--- a/RockLib.Logging/ILogger.cs
+++ b/RockLib.Logging/ILogger.cs
@@ -34,6 +34,11 @@ namespace RockLib.Logging
         IReadOnlyCollection<ILogProvider> Providers { get; }
 
         /// <summary>
+        /// Gets the collection of <see cref="IContextProvider"/> objects used by this logger.
+        /// </summary>
+        IReadOnlyCollection<IContextProvider> ContextProviders { get; }
+
+        /// <summary>
         /// Occurs when an error happens.
         /// </summary>
         event EventHandler<ErrorEventArgs> Error;

--- a/RockLib.Logging/ILogger.cs
+++ b/RockLib.Logging/ILogger.cs
@@ -34,6 +34,11 @@ namespace RockLib.Logging
         IReadOnlyCollection<ILogProvider> Providers { get; }
 
         /// <summary>
+        /// Occurs when an error happens.
+        /// </summary>
+        event EventHandler<ErrorEventArgs> Error;
+
+        /// <summary>
         /// Logs the specified log entry.
         /// </summary>
         /// <param name="logEntry">The log entry to log.</param>

--- a/RockLib.Logging/ILogger.cs
+++ b/RockLib.Logging/ILogger.cs
@@ -31,7 +31,7 @@ namespace RockLib.Logging
         /// <summary>
         /// Gets the collection of <see cref="ILogProvider"/> objects used by this logger.
         /// </summary>
-        IReadOnlyCollection<ILogProvider> Providers { get; }
+        IReadOnlyCollection<ILogProvider> LogProviders { get; }
 
         /// <summary>
         /// Gets the collection of <see cref="IContextProvider"/> objects used by this logger.

--- a/RockLib.Logging/LogEntry.cs
+++ b/RockLib.Logging/LogEntry.cs
@@ -107,6 +107,21 @@ namespace RockLib.Logging
         }
 
         /// <summary>
+        /// Gets or sets the ID used to corralate a transaction across many service calls for this log entry.
+        /// </summary>
+        public string CorrelationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the business process ID.
+        /// </summary>
+        public string BusinessProcessId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the business activity ID.
+        /// </summary>
+        public string BusinessActivityId { get; set; }
+
+        /// <summary>
         /// Gets or sets the IP addess of the machine where the current logging operation is taking place.
         /// This is set to a default value, detected at runtime.
         /// </summary>
@@ -122,6 +137,11 @@ namespace RockLib.Logging
         /// Gets or sets the message of the log entry.
         /// </summary>
         public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the caller information of the log entry.
+        /// </summary>
+        public string CallerInfo { get; set; }
 
         /// <summary>
         /// Gets or sets the username of the user that is performing the current logging operation.

--- a/RockLib.Logging/LogProviders/TemplateLogFormatter.cs
+++ b/RockLib.Logging/LogProviders/TemplateLogFormatter.cs
@@ -54,6 +54,9 @@ namespace RockLib.Logging
             AddSimpleTokenHandler("level", logEntry => logEntry.Level.ToString());
             AddSimpleTokenHandler("exception", logEntry => logEntry.GetExceptionData());
             AddSimpleTokenHandler("uniqueId", logEntry => logEntry.UniqueId);
+            AddSimpleTokenHandler("correlationId", logEntry => logEntry.CorrelationId);
+            AddSimpleTokenHandler("businessProcessId", logEntry => logEntry.BusinessProcessId);
+            AddSimpleTokenHandler("businessActivityId", logEntry => logEntry.BusinessActivityId);
 
             AddExtendedPropertyTokenHandler("callerInfo", "CallerInfo");
 

--- a/RockLib.Logging/Logger.cs
+++ b/RockLib.Logging/Logger.cs
@@ -1,4 +1,5 @@
-﻿using RockLib.Diagnostics;
+﻿using RockLib.Configuration.ObjectFactory;
+using RockLib.Diagnostics;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -24,7 +25,7 @@ namespace RockLib.Logging
         /// </summary>
         public const string DefaultName = "default";
     
-        private static readonly IReadOnlyCollection<ILogProvider> EmptyProviders = new ILogProvider[0];
+        private static readonly IReadOnlyCollection<ILogProvider> EmptyLogProviders = new ILogProvider[0];
         private static readonly IReadOnlyCollection<IContextProvider> EmptyContextProviders = new IContextProvider[0];
 
         /// <summary>
@@ -48,7 +49,7 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="name">The name of the logger.</param>
         /// <param name="level">The logging level of the logger.</param>
-        /// <param name="providers">A collection of <see cref="ILogProvider"/> objects used by this logger.</param>
+        /// <param name="logProviders">A collection of <see cref="ILogProvider"/> objects used by this logger.</param>
         /// <param name="isDisabled">A value indicating whether the logger is disabled.</param>
         /// <param name="isSynchronous">A value indicating whether the logger is synchrnous.</param>
         /// <param name="contextProviders">
@@ -57,7 +58,7 @@ namespace RockLib.Logging
         public Logger(
             string name = DefaultName,
             LogLevel level = LogLevel.NotSet,
-            IReadOnlyCollection<ILogProvider> providers = null,
+            [AlternateName("providers")] IReadOnlyCollection<ILogProvider> logProviders = null,
             bool isDisabled = false,
             bool isSynchronous = false,
             IReadOnlyCollection<IContextProvider> contextProviders = null)
@@ -67,12 +68,12 @@ namespace RockLib.Logging
 
             Name = name ?? DefaultName;
             Level = level;
-            Providers = providers ?? EmptyProviders;
+            LogProviders = logProviders ?? EmptyLogProviders;
             IsDisabled = isDisabled;
             IsSynchronous = isSynchronous;
             ContextProviders = contextProviders ?? EmptyContextProviders;
 
-            _canProcessLogs = !IsDisabled && Providers.Count > 0;
+            _canProcessLogs = !IsDisabled && LogProviders.Count > 0;
 
             if (!IsSynchronous)
             {
@@ -113,7 +114,7 @@ namespace RockLib.Logging
         /// <summary>
         /// Gets the collection of <see cref="ILogProvider"/> objects used by this logger.
         /// </summary>
-        public IReadOnlyCollection<ILogProvider> Providers { get; }
+        public IReadOnlyCollection<ILogProvider> LogProviders { get; }
 
         /// <summary>
         /// Gets a value indicating whether the logger is disabled.
@@ -188,7 +189,7 @@ namespace RockLib.Logging
             foreach (var contextProvider in ContextProviders)
                 contextProvider.AddContext(logEntry);
 
-            foreach (var logProvider in Providers)
+            foreach (var logProvider in LogProviders)
                 WriteToLogProvider(logEntry, logProvider);
         }
 
@@ -307,9 +308,9 @@ namespace RockLib.Logging
                     _trackingQueue.Dispose();
                 }
 
-                var providers = Providers?.GetEnumerator();
-                while (providers != null && providers.MoveNext())
-                    (providers.Current as IDisposable)?.Dispose();
+                var logProviders = LogProviders?.GetEnumerator();
+                while (logProviders != null && logProviders.MoveNext())
+                    (logProviders.Current as IDisposable)?.Dispose();
             }
         }
     }

--- a/RockLib.Logging/Logger.cs
+++ b/RockLib.Logging/Logger.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +17,7 @@ namespace RockLib.Logging
     /// With the exception of the <see cref="Dispose()"/> method, all public instance members
     /// of this class are thread-safe.
     /// </remarks>
-    public sealed class Logger : ILogger, IDisposable
+    public sealed class Logger : ILogger
     {
         /// <summary>
         /// The default logger name.

--- a/RockLib.Logging/Logger.cs
+++ b/RockLib.Logging/Logger.cs
@@ -187,7 +187,7 @@ namespace RockLib.Logging
             if (logEntry.Level < Level)
                 return;
 
-            logEntry.ExtendedProperties["CallerInfo"] = $"{callerFilePath}:{callerMemberName}({callerLineNumber})";
+            logEntry.CallerInfo = $"{callerFilePath}:{callerMemberName}({callerLineNumber})";
             // TODO: Invoke any context providers
 
             foreach (var logProvider in Providers)

--- a/RockLib.Logging/LoggerFactory.cs
+++ b/RockLib.Logging/LoggerFactory.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Resolver = RockLib.Configuration.ObjectFactory.Resolver;
 
 namespace RockLib.Logging
 {

--- a/RockLib.Logging/LoggerFactory.cs
+++ b/RockLib.Logging/LoggerFactory.cs
@@ -1,112 +1,159 @@
-﻿using RockLib.Configuration;
+﻿using Microsoft.Extensions.Configuration;
+using RockLib.Configuration;
 using RockLib.Configuration.ObjectFactory;
 using RockLib.Immutable;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace RockLib.Logging
 {
     /// <summary>
-    /// A static class that retrieves instances of the <see cref="Logger"/> class by name. The available
-    /// logger instances are set from configuration by default, but can be set programmatically if needed.
+    /// A static class that creates and retrieves instances of the <see cref="ILogger"/> interface by name.
+    /// Loggers returned by this factory are defined by instances of the <see cref="IConfiguration"/> interface.
     /// </summary>
-    /// <remarks>
-    /// The following code snippet defines how the default loggers are initialized:
-    /// <code>
-    /// using RockLib.Configuration;
-    /// using RockLib.Configuration.ObjectFactory;
-    /// 
-    /// Config.Root.GetSection("rocklib.logging").Create&lt;IReadOnlyCollection&lt;Logger&gt;&gt;();
-    /// </code>
-    /// </remarks>
     public static class LoggerFactory
     {
         /// <summary>
         /// The section name, relative to <see cref="Config.Root"/>, from which to retrieve logging settings.
         /// </summary>
-        public const string SectionName = "rocklib.logging";
+        public const string SectionName = "RockLib.Logging";
 
-        private static readonly ConcurrentDictionary<string, Logger> _lookup = new ConcurrentDictionary<string, Logger>(StringComparer.InvariantCultureIgnoreCase);
+        private static readonly ConditionalWeakTable<IConfiguration, ConcurrentDictionary<string, ILogger>> _cache = new ConditionalWeakTable<IConfiguration, ConcurrentDictionary<string, ILogger>>();
 
-        private static readonly Semimutable<IReadOnlyCollection<Logger>> _loggers = new Semimutable<IReadOnlyCollection<Logger>>(CreateDefaultLoggers);
-
-        /// <summary>
-        /// Gets the loggers that are avilable to the <see cref="GetInstance"/> method to select from.
-        /// </summary>
-        public static IReadOnlyCollection<Logger> Loggers => _loggers.Value;
+        private static readonly Semimutable<IConfiguration> _configuration =
+            new Semimutable<IConfiguration>(() => Config.Root.GetSection(SectionName));
 
         /// <summary>
-        /// Sets the loggers that will be avilable to the <see cref="GetInstance"/> method to select from.
+        /// Sets the instance of <see cref="IConfiguration"/> that defines the loggers that can be created
+        /// or retrieved. Note that once the <see cref="Configuration"/> property has been read from, it
+        /// cannot be changed.
         /// </summary>
-        /// <param name="loggers">
-        /// The loggers that will be avilable to the <see cref="GetInstance"/> method to select from.
+        /// <param name="configuration">
+        /// An instance of <see cref="IConfiguration"/> that defines the loggers that can be retrieved. The
+        /// configuration can define a single logger object or a list of logger objects.
         /// </param>
-        public static void SetLoggers(IReadOnlyCollection<Logger> loggers) =>
-            _loggers.Value = loggers ?? throw new ArgumentNullException(nameof(loggers));
+        public static void SetConfiguration(IConfiguration configuration) => _configuration.Value = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
         /// <summary>
-        /// Returns the first <see cref="Logger"/> from the <see cref="Loggers"/> property that has a
-        /// <see cref="Logger.Name"/> that matches (case-insensitive) the <paramref name="name"/>
-        /// parameter.
+        /// Gets the instance of <see cref="IConfiguration"/> that defines the loggers that can be created
+        /// or retrieved.
+        /// </summary>
+        /// <remarks>
+        /// Only the extension methods in this class that do not have an <see cref="IConfiguration"/> parameter
+        /// use this property.
+        /// </remarks>
+        public static IConfiguration Configuration => _configuration.Value;
+
+        /// <summary>
+        /// Gets a cached instance of <see cref="ILogger"/> with a name matching the <paramref name="name"/>
+        /// parameter that is backed by the value of the <see cref="Configuration"/> property.
         /// </summary>
         /// <param name="name">The name of the logger to retrieve.</param>
         /// <returns>A logger with a matching name.</returns>
         /// <exception cref="KeyNotFoundException">
-        /// If the <see cref="Loggers"/> property does not contain a logger with the specified name.
+        /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
+        /// the value of the <see cref="Configuration"/> property.
         /// </exception>
-        public static Logger GetInstance(string name = Logger.DefaultName) => _lookup.GetOrAdd(name ?? Logger.DefaultName, FindLogger);
+        public static ILogger GetCached(string name = Logger.DefaultName) => Configuration.GetCachedLogger(name);
 
         /// <summary>
-        /// Creates a new instance of the <see cref="Logger"/> class using the configuration found in the
-        /// section named <see cref="SectionName"/> in <see cref="Config.Root"/> according to the specified name.
+        /// Gets a cached instance of <see cref="ILogger"/> with a name matching the <paramref name="name"/>
+        /// parameter that is backed by the value of the <paramref name="configuration"/> parameter.
         /// </summary>
-        /// <param name="name">The name of the logger to create, as matched in configuration.</param>
-        /// <returns>A new instance of the <see cref="Logger"/> class.</returns>
-        /// <remarks>
-        /// The logger returned from this method is *not* cached. That is, a new instance is returned every time this method is called.
-        /// </remarks>
-        public static Logger CreateFromConfig(string name = Logger.DefaultName)
+        /// <param name="configuration">
+        /// An instance of <see cref="IConfiguration"/> that defines the loggers that can be retrieved. The
+        /// configuration can define a single logger object or a list of logger objects.
+        /// </param>
+        /// <param name="name">The name of the logger to retrieve.</param>
+        /// <returns>A logger with a matching name.</returns>
+        /// <exception cref="KeyNotFoundException">
+        /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
+        /// the value of the <paramref name="configuration"/> parameter.
+        /// </exception>
+        public static ILogger GetCachedLogger(this IConfiguration configuration, string name = Logger.DefaultName)
         {
-            var loggingSection = Config.Root.GetSection(SectionName);
-            if (loggingSection.GetChildren().Any(c => int.TryParse(c.Key, out var dummy)))
-            {
-                foreach (var child in loggingSection.GetChildren())
-                    if ((child[nameof(Logger.Name)] ?? Logger.DefaultName) == name)
-                        return child.Create<Logger>();
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (name == null) throw new ArgumentNullException(nameof(name));
 
-                throw new KeyNotFoundException($"The {SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
-            }
-            else
-            {
-                if ((loggingSection[nameof(Logger.Name)] ?? Logger.DefaultName) == name)
-                    return loggingSection.Create<Logger>();
-
-                throw new KeyNotFoundException($"The {SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
-            }
+            var configCache = _cache.GetValue(configuration, c => new ConcurrentDictionary<string, ILogger>());
+            return configCache.GetOrAdd(name, n => configuration.CreateLogger(n));
         }
 
         /// <summary>
-        /// Calls the <see cref="Logger.Dispose()"/> method on each logger in the <see cref="Loggers"/> property,
-        /// blocking until any of their pending logging operations have completed.
+        /// Creates a new instance of <see cref="ILogger"/> with a name matching the <paramref name="name"/>
+        /// parameter that is backed by the value of the <see cref="Configuration"/> property.
         /// </summary>
-        public static void ShutDown()
-        {
-            if (_loggers.IsLocked)
-                foreach (var logger in Loggers)
-                    logger.Dispose();
-        }
-
-        private static Logger FindLogger(string name) =>
-            Loggers.FirstOrDefault(logger => logger.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
-            ?? throw new KeyNotFoundException($"LoggerFactory.Loggers does not contain a Logger with the name '{name}'.");
+        /// <param name="name">The name of the logger to create.</param>
+        /// <returns>A new logger with a matching name.</returns>
+        /// <exception cref="KeyNotFoundException">
+        /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
+        /// the value of the <see cref="Configuration"/> property.
+        /// </exception>
+        public static ILogger Create(string name = Logger.DefaultName) => Configuration.CreateLogger(name);
 
         /// <summary>
-        /// Defines the method used to create the default value of the <see cref="Loggers"/> property.
+        /// Creates a new instance of <see cref="ILogger"/> with a name matching the <paramref name="name"/>
+        /// parameter that is backed by the value of the <paramref name="configuration"/> parameter.
         /// </summary>
-        /// <returns>A collection of new <see cref="Logger"/> objects.</returns>
-        public static IReadOnlyCollection<Logger> CreateDefaultLoggers() =>
-             Config.Root.GetSection(SectionName).Create<IReadOnlyCollection<Logger>>();
+        /// <param name="configuration">
+        /// An instance of <see cref="IConfiguration"/> that defines the loggers that can be retrieved. The
+        /// configuration can define a single logger object or a list of logger objects.
+        /// </param>
+        /// <param name="name">The name of the logger to create.</param>
+        /// <returns>A new logger with a matching name.</returns>
+        /// <exception cref="KeyNotFoundException">
+        /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
+        /// the value of the <paramref name="configuration"/> parameter.
+        /// </exception>
+        public static ILogger CreateLogger(this IConfiguration configuration, string name = Logger.DefaultName)
+        {
+            var defaultTypes = new DefaultTypes().Add(typeof(ILogger), typeof(Logger));
+
+            if (configuration.IsList())
+            {
+                foreach (var child in configuration.GetChildren())
+                    if (name.Equals(child.GetSectionName(), StringComparison.OrdinalIgnoreCase))
+                        return child.CreateReloadingProxy<ILogger>(defaultTypes);
+            }
+            else if (name.Equals(configuration.GetSectionName(), StringComparison.OrdinalIgnoreCase))
+                return configuration.CreateReloadingProxy<ILogger>(defaultTypes);
+
+            throw new KeyNotFoundException($"No loggers were found matching the name '{name}'.");
+        }
+
+        private static bool IsEmpty(this IConfiguration configuration)
+        {
+            switch (configuration)
+            {
+                case IConfigurationSection section:
+                    return section.Value == null && !section.GetChildren().Any();
+                default:
+                    return !configuration.GetChildren().Any();
+            }
+        }
+
+        private static bool IsList(this IConfiguration configuration)
+        {
+            if (configuration is IConfigurationSection section && section.Value != null)
+                return false;
+            int i = 0;
+            foreach (var child in configuration.GetChildren())
+                if (child.Key != i++.ToString())
+                    return false;
+            return i > 0;
+        }
+
+        private static string GetSectionName(this IConfiguration configuration)
+        {
+            var section = configuration;
+
+            if (configuration["type"] != null && !configuration.GetSection("value").IsEmpty())
+                section = configuration.GetSection("value");
+
+            return section["name"] ?? Logger.DefaultName;
+        }
     }
 }

--- a/RockLib.Logging/LoggerFactory.cs
+++ b/RockLib.Logging/LoggerFactory.cs
@@ -23,6 +23,11 @@ namespace RockLib.Logging
     /// </remarks>
     public static class LoggerFactory
     {
+        /// <summary>
+        /// The section name, relative to <see cref="Config.Root"/>, from which to retrieve logging settings.
+        /// </summary>
+        public const string SectionName = "rocklib.logging";
+
         private static readonly ConcurrentDictionary<string, Logger> _lookup = new ConcurrentDictionary<string, Logger>(StringComparer.InvariantCultureIgnoreCase);
 
         private static readonly Semimutable<IReadOnlyCollection<Logger>> _loggers = new Semimutable<IReadOnlyCollection<Logger>>(CreateDefaultLoggers);
@@ -54,13 +59,43 @@ namespace RockLib.Logging
         public static Logger GetInstance(string name = Logger.DefaultName) => _lookup.GetOrAdd(name ?? Logger.DefaultName, FindLogger);
 
         /// <summary>
-        /// Calls the <see cref="Logger.Dispose"/> method on each logger in the <see cref="Loggers"/> property,
+        /// Creates a new instance of the <see cref="Logger"/> class using the configuration found in the
+        /// section named <see cref="SectionName"/> in <see cref="Config.Root"/> according to the specified name.
+        /// </summary>
+        /// <param name="name">The name of the logger to create, as matched in configuration.</param>
+        /// <returns>A new instance of the <see cref="Logger"/> class.</returns>
+        /// <remarks>
+        /// The logger returned from this method is *not* cached. That is, a new instance is returned every time this method is called.
+        /// </remarks>
+        public static Logger CreateFromConfig(string name = Logger.DefaultName)
+        {
+            var loggingSection = Config.Root.GetSection(SectionName);
+            if (loggingSection.GetChildren().Any(c => int.TryParse(c.Key, out var dummy)))
+            {
+                foreach (var child in loggingSection.GetChildren())
+                    if ((child[nameof(Logger.Name)] ?? Logger.DefaultName) == name)
+                        return child.Create<Logger>();
+
+                throw new KeyNotFoundException($"The {SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
+            }
+            else
+            {
+                if ((loggingSection[nameof(Logger.Name)] ?? Logger.DefaultName) == name)
+                    return loggingSection.Create<Logger>();
+
+                throw new KeyNotFoundException($"The {SectionName} section in RockLib.Configuration.Config.Root does not contain a Logger configuration with the name '{name}'.");
+            }
+        }
+
+        /// <summary>
+        /// Calls the <see cref="Logger.Dispose()"/> method on each logger in the <see cref="Loggers"/> property,
         /// blocking until any of their pending logging operations have completed.
         /// </summary>
         public static void ShutDown()
         {
-            foreach (var logger in Loggers)
-                logger.Dispose();
+            if (_loggers.IsLocked)
+                foreach (var logger in Loggers)
+                    logger.Dispose();
         }
 
         private static Logger FindLogger(string name) =>
@@ -72,6 +107,6 @@ namespace RockLib.Logging
         /// </summary>
         /// <returns>A collection of new <see cref="Logger"/> objects.</returns>
         public static IReadOnlyCollection<Logger> CreateDefaultLoggers() =>
-             Config.Root.GetSection("rocklib.logging").Create<IReadOnlyCollection<Logger>>();
+             Config.Root.GetSection(SectionName).Create<IReadOnlyCollection<Logger>>();
     }
 }

--- a/RockLib.Logging/LoggerFactory.cs
+++ b/RockLib.Logging/LoggerFactory.cs
@@ -52,12 +52,33 @@ namespace RockLib.Logging
         /// parameter that is backed by the value of the <see cref="Configuration"/> property.
         /// </summary>
         /// <param name="name">The name of the logger to retrieve.</param>
+        /// <param name="defaultTypes">
+        /// An object that defines the default types to be used when a type is not explicitly specified by a
+        /// configuration section.
+        /// </param>
+        /// <param name="valueConverters">
+        /// An object that defines custom converter functions that are used to convert string configuration
+        /// values to a target type.
+        /// </param>
+        /// <param name="resolver">
+        /// An object that can retrieve constructor parameter values that are not found in configuration. This
+        /// object is an adapter for dependency injection containers, such as Ninject, Unity, Autofac, or
+        /// StructureMap. Consider using the <see cref="Resolver"/> class for this parameter, as it supports
+        /// most depenedency injection containers.
+        /// </param>
+        /// <param name="reloadOnConfigChange">
+        /// Whether to create an instance of <see cref="ILogger"/> that automatically reloads itself when its
+        /// configuration changes. Default is true.
+        /// </param>
         /// <returns>A logger with a matching name.</returns>
         /// <exception cref="KeyNotFoundException">
         /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
         /// the value of the <see cref="Configuration"/> property.
         /// </exception>
-        public static ILogger GetCached(string name = Logger.DefaultName) => Configuration.GetCachedLogger(name);
+        public static ILogger GetCached(string name = Logger.DefaultName,
+            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null,
+            IResolver resolver = null, bool reloadOnConfigChange = true) => 
+            Configuration.GetCachedLogger(name, defaultTypes, valueConverters, resolver, reloadOnConfigChange);
 
         /// <summary>
         /// Gets a cached instance of <see cref="ILogger"/> with a name matching the <paramref name="name"/>
@@ -68,18 +89,38 @@ namespace RockLib.Logging
         /// configuration can define a single logger object or a list of logger objects.
         /// </param>
         /// <param name="name">The name of the logger to retrieve.</param>
+        /// <param name="defaultTypes">
+        /// An object that defines the default types to be used when a type is not explicitly specified by a
+        /// configuration section.
+        /// </param>
+        /// <param name="valueConverters">
+        /// An object that defines custom converter functions that are used to convert string configuration
+        /// values to a target type.
+        /// </param>
+        /// <param name="resolver">
+        /// An object that can retrieve constructor parameter values that are not found in configuration. This
+        /// object is an adapter for dependency injection containers, such as Ninject, Unity, Autofac, or
+        /// StructureMap. Consider using the <see cref="Resolver"/> class for this parameter, as it supports
+        /// most depenedency injection containers.
+        /// </param>
+        /// <param name="reloadOnConfigChange">
+        /// Whether to create an instance of <see cref="ILogger"/> that automatically reloads itself when its
+        /// configuration changes. Default is true.
+        /// </param>
         /// <returns>A logger with a matching name.</returns>
         /// <exception cref="KeyNotFoundException">
         /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
         /// the value of the <paramref name="configuration"/> parameter.
         /// </exception>
-        public static ILogger GetCachedLogger(this IConfiguration configuration, string name = Logger.DefaultName)
+        public static ILogger GetCachedLogger(this IConfiguration configuration, string name = Logger.DefaultName,
+            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null,
+            IResolver resolver = null, bool reloadOnConfigChange = true)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             if (name == null) throw new ArgumentNullException(nameof(name));
 
             var configCache = _cache.GetValue(configuration, c => new ConcurrentDictionary<string, ILogger>());
-            return configCache.GetOrAdd(name, n => configuration.CreateLogger(n));
+            return configCache.GetOrAdd(name, n => configuration.CreateLogger(n, defaultTypes, valueConverters, resolver, reloadOnConfigChange));
         }
 
         /// <summary>
@@ -87,12 +128,33 @@ namespace RockLib.Logging
         /// parameter that is backed by the value of the <see cref="Configuration"/> property.
         /// </summary>
         /// <param name="name">The name of the logger to create.</param>
+        /// <param name="defaultTypes">
+        /// An object that defines the default types to be used when a type is not explicitly specified by a
+        /// configuration section.
+        /// </param>
+        /// <param name="valueConverters">
+        /// An object that defines custom converter functions that are used to convert string configuration
+        /// values to a target type.
+        /// </param>
+        /// <param name="resolver">
+        /// An object that can retrieve constructor parameter values that are not found in configuration. This
+        /// object is an adapter for dependency injection containers, such as Ninject, Unity, Autofac, or
+        /// StructureMap. Consider using the <see cref="Resolver"/> class for this parameter, as it supports
+        /// most depenedency injection containers.
+        /// </param>
+        /// <param name="reloadOnConfigChange">
+        /// Whether to create an instance of <see cref="ILogger"/> that automatically reloads itself when its
+        /// configuration changes. Default is true.
+        /// </param>
         /// <returns>A new logger with a matching name.</returns>
         /// <exception cref="KeyNotFoundException">
         /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
         /// the value of the <see cref="Configuration"/> property.
         /// </exception>
-        public static ILogger Create(string name = Logger.DefaultName) => Configuration.CreateLogger(name);
+        public static ILogger Create(string name = Logger.DefaultName,
+            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null,
+            IResolver resolver = null, bool reloadOnConfigChange = true) =>
+            Configuration.CreateLogger(name, defaultTypes, valueConverters, resolver, reloadOnConfigChange);
 
         /// <summary>
         /// Creates a new instance of <see cref="ILogger"/> with a name matching the <paramref name="name"/>
@@ -103,23 +165,50 @@ namespace RockLib.Logging
         /// configuration can define a single logger object or a list of logger objects.
         /// </param>
         /// <param name="name">The name of the logger to create.</param>
+        /// <param name="defaultTypes">
+        /// An object that defines the default types to be used when a type is not explicitly specified by a
+        /// configuration section.
+        /// </param>
+        /// <param name="valueConverters">
+        /// An object that defines custom converter functions that are used to convert string configuration
+        /// values to a target type.
+        /// </param>
+        /// <param name="resolver">
+        /// An object that can retrieve constructor parameter values that are not found in configuration. This
+        /// object is an adapter for dependency injection containers, such as Ninject, Unity, Autofac, or
+        /// StructureMap. Consider using the <see cref="Resolver"/> class for this parameter, as it supports
+        /// most depenedency injection containers.
+        /// </param>
+        /// <param name="reloadOnConfigChange">
+        /// Whether to create an instance of <see cref="ILogger"/> that automatically reloads itself when its
+        /// configuration changes. Default is true.
+        /// </param>
         /// <returns>A new logger with a matching name.</returns>
         /// <exception cref="KeyNotFoundException">
         /// If a logger with a name specified by the <paramref name="name"/> parameter is not defined in
         /// the value of the <paramref name="configuration"/> parameter.
         /// </exception>
-        public static ILogger CreateLogger(this IConfiguration configuration, string name = Logger.DefaultName)
+        public static ILogger CreateLogger(this IConfiguration configuration, string name = Logger.DefaultName,
+            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null,
+            IResolver resolver = null, bool reloadOnConfigChange = true)
         {
-            var defaultTypes = new DefaultTypes().Add(typeof(ILogger), typeof(Logger));
+            if (defaultTypes == null)
+                defaultTypes = new DefaultTypes();
+            if (!defaultTypes.TryGet(typeof(ILogger), out var dummy))
+                defaultTypes.Add(typeof(ILogger), typeof(Logger));
 
             if (configuration.IsList())
             {
                 foreach (var child in configuration.GetChildren())
                     if (name.Equals(child.GetSectionName(), StringComparison.OrdinalIgnoreCase))
-                        return child.CreateReloadingProxy<ILogger>(defaultTypes);
+                        return reloadOnConfigChange
+                            ? child.CreateReloadingProxy<ILogger>(defaultTypes, valueConverters, resolver)
+                            : child.Create<ILogger>(defaultTypes, valueConverters, resolver);
             }
             else if (name.Equals(configuration.GetSectionName(), StringComparison.OrdinalIgnoreCase))
-                return configuration.CreateReloadingProxy<ILogger>(defaultTypes);
+                return reloadOnConfigChange
+                    ? configuration.CreateReloadingProxy<ILogger>(defaultTypes, valueConverters, resolver)
+                    : configuration.Create<ILogger>(defaultTypes, valueConverters, resolver);
 
             throw new KeyNotFoundException($"No loggers were found matching the name '{name}'.");
         }

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Configuration" Version="2.2.0" />
-    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.1.4" />
+    <PackageReference Include="RockLib.Configuration" Version="2.2.1" />
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.2.0" />
     <PackageReference Include="RockLib.Diagnostics" Version="1.0.1" />
   </ItemGroup>
 

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>2.0.0-alpha00</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Logging/blob/master/LICENSE.md</PackageLicenseUrl>
     <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>RockLib Logging Logger</PackageTags>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Configuration" Version="2.2.1" />
-    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.2.0" />
+    <PackageReference Include="RockLib.Configuration" Version="2.3.0" />
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.2.2" />
     <PackageReference Include="RockLib.Diagnostics" Version="1.0.1" />
   </ItemGroup>
 

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -24,13 +24,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Configuration" Version="2.3.0" />
-    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.2.2" />
+    <PackageReference Include="RockLib.Configuration" Version="2.3.1" />
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.4.0" />
     <PackageReference Include="RockLib.Diagnostics" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net451'">
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <Import Project="..\RockLib.Reflection.Optimized\RockLib.Reflection.Optimized.Shared\RockLib.Reflection.Optimized.Shared.projitems" Label="Shared" />

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>2.0.0-alpha01</PackageVersion>
+    <PackageVersion>2.0.0-alpha02</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>2.0.0-alpha00</PackageVersion>
+    <PackageVersion>2.0.0-alpha01</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>2.0.0-alpha02</PackageVersion>
+    <PackageVersion>2.0.0-alpha03</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Logging/blob/master/LICENSE.md</PackageLicenseUrl>
     <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>RockLib Logging Logger</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Configuration" Version="2.0.0" />
-    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.1.2" />
+    <PackageReference Include="RockLib.Configuration" Version="2.2.0" />
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.1.4" />
     <PackageReference Include="RockLib.Diagnostics" Version="1.0.1" />
   </ItemGroup>
 

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="RockLib.Configuration" Version="2.3.1" />
-    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.4.0" />
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.6.0" />
     <PackageReference Include="RockLib.Diagnostics" Version="1.0.1" />
   </ItemGroup>
 

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>1.0.1</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <Authors>Quicken Loans</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Logging/blob/master/LICENSE.md</PackageLicenseUrl>
     <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>RockLib Logging Logger</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/RockLib.Logging/Sync.cs
+++ b/RockLib.Logging/Sync.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RockLib.Logging
+{
+    internal static class Sync
+    {
+        public static void OverAsync(Func<Task> getTaskOfTResult)
+        {
+            SynchronizationContext old = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                getTaskOfTResult().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(old);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a collection of `IContextProvider` objects to the `Logger` class that are intended to modify the `LogEntry` objects passed to its `Log` method before the log providers send them.