### PR TITLE
Add context provider feature

### DIFF
--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -492,6 +492,8 @@ namespace RockLib.Logging.Tests
             public bool IsDisabled { get; }
             public LogLevel Level { get; }
             public IReadOnlyCollection<ILogProvider> Providers { get; }
+            public IReadOnlyCollection<IContextProvider> ContextProviders { get; }
+
             public event EventHandler<ErrorEventArgs> Error;
 
             public void Log(LogEntry logEntry, string callerMemberName = null, string callerFilePath = null, int callerLineNumber = 0)

--- a/RockLib.Logging.Tests/LoggerFactoryTests.cs
+++ b/RockLib.Logging.Tests/LoggerFactoryTests.cs
@@ -15,32 +15,8 @@ namespace RockLib.Logging.Tests
 {
     public class LoggerFactoryTests
     {
-        [Theory]
-        [InlineData(Logger.DefaultName, typeof(FooLogProvider))]
-        [InlineData("bar", typeof(BarLogProvider))]
-        public void CreateLoggerWorksWithListOfLoggers(string name, Type expectedLogProviderType)
-        {
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>()
-                {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
-                    ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
-                })
-                .Build()
-                .GetSection("rocklib.logging");
-
-            var logger = config.CreateLogger(name);
-
-            logger.Name.Should().Be(name);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(expectedLogProviderType);
-
-            config.CreateLogger(name).Should().NotBeSameAs(logger);
-        }
-
         [Fact]
-        public void CreateLoggerWorksWithSingleUnnamedLogger()
+        public void LegacyConfigurationFormatIsSupported()
         {
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -53,8 +29,52 @@ namespace RockLib.Logging.Tests
             var logger = config.CreateLogger();
 
             logger.Name.Should().Be(Logger.DefaultName);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
+
+            config.CreateLogger().Should().NotBeSameAs(logger);
+        }
+
+        [Theory]
+        [InlineData(Logger.DefaultName, typeof(FooLogProvider))]
+        [InlineData("bar", typeof(BarLogProvider))]
+        public void CreateLoggerWorksWithListOfLoggers(string name, Type expectedLogProviderType)
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:name"] = "bar",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
+
+            var logger = config.CreateLogger(name);
+
+            logger.Name.Should().Be(name);
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(expectedLogProviderType);
+
+            config.CreateLogger(name).Should().NotBeSameAs(logger);
+        }
+
+        [Fact]
+        public void CreateLoggerWorksWithSingleUnnamedLogger()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                })
+                .Build()
+                .GetSection("rocklib.logging");
+
+            var logger = config.CreateLogger();
+
+            logger.Name.Should().Be(Logger.DefaultName);
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
             config.CreateLogger().Should().NotBeSameAs(logger);
         }
@@ -66,7 +86,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -74,8 +94,8 @@ namespace RockLib.Logging.Tests
             var logger = config.CreateLogger("bar");
 
             logger.Name.Should().Be("bar");
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(BarLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(BarLogProvider));
 
             config.CreateLogger("bar").Should().NotBeSameAs(logger);
         }
@@ -86,9 +106,9 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                     ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -106,7 +126,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -125,9 +145,9 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                     ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -135,8 +155,8 @@ namespace RockLib.Logging.Tests
             var logger = config.GetCachedLogger(name);
 
             logger.Name.Should().Be(name);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(expectedLogProviderType);
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(expectedLogProviderType);
 
             config.GetCachedLogger(name).Should().BeSameAs(logger);
         }
@@ -147,7 +167,7 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -155,8 +175,8 @@ namespace RockLib.Logging.Tests
             var logger = config.GetCachedLogger();
 
             logger.Name.Should().Be(Logger.DefaultName);
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
             config.GetCachedLogger().Should().BeSameAs(logger);
         }
@@ -168,7 +188,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -176,8 +196,8 @@ namespace RockLib.Logging.Tests
             var logger = config.GetCachedLogger("bar");
 
             logger.Name.Should().Be("bar");
-            logger.Providers.Count.Should().Be(1);
-            logger.Providers.First().Should().BeOfType(typeof(BarLogProvider));
+            logger.LogProviders.Count.Should().Be(1);
+            logger.LogProviders.First().Should().BeOfType(typeof(BarLogProvider));
 
             config.GetCachedLogger("bar").Should().BeSameAs(logger);
         }
@@ -188,9 +208,9 @@ namespace RockLib.Logging.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:0:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:0:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                     ["rocklib.logging:1:name"] = "bar",
-                    ["rocklib.logging:1:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:1:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -208,7 +228,7 @@ namespace RockLib.Logging.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     ["rocklib.logging:name"] = "bar",
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.BarLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("rocklib.logging");
@@ -253,7 +273,7 @@ namespace RockLib.Logging.Tests
             var config = new InterceptingConfigurationSection(new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("RockLib.Logging"));
@@ -267,8 +287,8 @@ namespace RockLib.Logging.Tests
                 config.Usages.Should().BeGreaterThan(0);
 
                 logger.Name.Should().Be(Logger.DefaultName);
-                logger.Providers.Count.Should().Be(1);
-                logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+                logger.LogProviders.Count.Should().Be(1);
+                logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
                 LoggerFactory.Create().Should().NotBeSameAs(logger);
             }
@@ -290,7 +310,7 @@ namespace RockLib.Logging.Tests
             var config = new InterceptingConfigurationSection(new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    ["rocklib.logging:Providers:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
+                    ["rocklib.logging:LogProviders:type"] = "RockLib.Logging.Tests.FooLogProvider, RockLib.Logging.Tests",
                 })
                 .Build()
                 .GetSection("RockLib.Logging"));
@@ -304,8 +324,8 @@ namespace RockLib.Logging.Tests
                 config.Usages.Should().BeGreaterThan(0);
 
                 logger.Name.Should().Be(Logger.DefaultName);
-                logger.Providers.Count.Should().Be(1);
-                logger.Providers.First().Should().BeOfType(typeof(FooLogProvider));
+                logger.LogProviders.Count.Should().Be(1);
+                logger.LogProviders.First().Should().BeOfType(typeof(FooLogProvider));
 
                 LoggerFactory.GetCached().Should().BeSameAs(logger);
             }
@@ -491,7 +511,7 @@ namespace RockLib.Logging.Tests
             public string Name { get; }
             public bool IsDisabled { get; }
             public LogLevel Level { get; }
-            public IReadOnlyCollection<ILogProvider> Providers { get; }
+            public IReadOnlyCollection<ILogProvider> LogProviders { get; }
             public IReadOnlyCollection<IContextProvider> ContextProviders { get; }
 
             public event EventHandler<ErrorEventArgs> Error;

--- a/RockLib.Logging.Tests/LoggerTests.cs
+++ b/RockLib.Logging.Tests/LoggerTests.cs
@@ -29,11 +29,11 @@ namespace RockLib.Logging.Tests
         [Fact]
         public void ProvidersIsSetFromConstructor()
         {
-            var providers = new ILogProvider[0];
+            var logProviders = new ILogProvider[0];
 
-            var logger = new Logger(providers: providers);
+            var logger = new Logger(logProviders: logProviders);
 
-            logger.Providers.Should().BeSameAs(providers);
+            logger.LogProviders.Should().BeSameAs(logProviders);
         }
 
         [Fact]
@@ -57,14 +57,14 @@ namespace RockLib.Logging.Tests
         {
             var name = "foo";
             var level = LogLevel.Warn;
-            var providers = new ILogProvider[0];
+            var logProviders = new ILogProvider[0];
             var isDisabled = true;
 
-            var logger = new Logger(name, level, providers, isDisabled);
+            var logger = new Logger(name, level, logProviders, isDisabled);
 
             logger.Name.Should().Be(name);
             logger.Level.Should().Be(level);
-            logger.Providers.Should().BeSameAs(providers);
+            logger.LogProviders.Should().BeSameAs(logProviders);
             logger.IsDisabled.Should().Be(isDisabled);
             logger.IsSynchronous.Should().BeFalse();
         }
@@ -96,7 +96,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -120,7 +120,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info, isDisabled: true);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info, isDisabled: true);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -139,7 +139,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Error);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Error);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -161,7 +161,7 @@ namespace RockLib.Logging.Tests
                 auditLevelLogProvider,
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -180,7 +180,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -195,7 +195,7 @@ namespace RockLib.Logging.Tests
         {
             var logProvider = new SemaphoreDelayedLogProvider();
 
-            var logger = new Logger(providers: new[] { logProvider }, level: LogLevel.Info);
+            var logger = new Logger(logProviders: new[] { logProvider }, level: LogLevel.Info);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 
@@ -222,7 +222,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info, isSynchronous: true);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info, isSynchronous: true);
 
             var type = typeof(Logger);
             var processingThreadField = type.GetField("_processingThread", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -241,7 +241,7 @@ namespace RockLib.Logging.Tests
                 new SynchronousLogProvider()
             };
 
-            var logger = new Logger(providers: logProviders, level: LogLevel.Info, isSynchronous: true);
+            var logger = new Logger(logProviders: logProviders, level: LogLevel.Info, isSynchronous: true);
 
             var logEntry = new LogEntry("Hello, world!", LogLevel.Info);
 

--- a/RockLib.Logging.Tests/appsettings.json
+++ b/RockLib.Logging.Tests/appsettings.json
@@ -2,7 +2,7 @@
     "rocklib.logging": {
         "Name": "TestLogger",
         "Level": "Info",
-        "Providers": {
+        "LogProviders": {
             "type": "RockLib.Logging.ConsoleLogProvider, RockLib.Logging",
             "value": {
                 "template": "foo bar",

--- a/RockLib.Logging/IContextProvider.cs
+++ b/RockLib.Logging/IContextProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace RockLib.Logging
+{
+    /// <summary>
+    /// Defines an object that adds custom context to <see cref="LogEntry"/> objects.
+    /// </summary>
+    public interface IContextProvider
+    {
+        /// <summary>
+        /// Add custom context to the <see cref="LogEntry"/> object.
+        /// </summary>
+        /// <param name="logEntry">The log entry to add custom context to.</param>
+        void AddContext(LogEntry logEntry);
+    }
+}

--- a/RockLib.Logging/ILogger.cs
+++ b/RockLib.Logging/ILogger.cs
@@ -34,6 +34,11 @@ namespace RockLib.Logging
         IReadOnlyCollection<ILogProvider> Providers { get; }
 
         /// <summary>
+        /// Gets the collection of <see cref="IContextProvider"/> objects used by this logger.
+        /// </summary>
+        IReadOnlyCollection<IContextProvider> ContextProviders { get; }
+
+        /// <summary>
         /// Occurs when an error happens.
         /// </summary>
         event EventHandler<ErrorEventArgs> Error;

--- a/RockLib.Logging/ILogger.cs
+++ b/RockLib.Logging/ILogger.cs
@@ -31,7 +31,7 @@ namespace RockLib.Logging
         /// <summary>
         /// Gets the collection of <see cref="ILogProvider"/> objects used by this logger.
         /// </summary>
-        IReadOnlyCollection<ILogProvider> Providers { get; }
+        IReadOnlyCollection<ILogProvider> LogProviders { get; }
 
         /// <summary>
         /// Gets the collection of <see cref="IContextProvider"/> objects used by this logger.

--- a/RockLib.Logging/Logger.cs
+++ b/RockLib.Logging/Logger.cs
@@ -1,4 +1,5 @@
-﻿using RockLib.Diagnostics;
+﻿using RockLib.Configuration.ObjectFactory;
+using RockLib.Diagnostics;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -24,7 +25,7 @@ namespace RockLib.Logging
         /// </summary>
         public const string DefaultName = "default";
     
-        private static readonly IReadOnlyCollection<ILogProvider> EmptyProviders = new ILogProvider[0];
+        private static readonly IReadOnlyCollection<ILogProvider> EmptyLogProviders = new ILogProvider[0];
         private static readonly IReadOnlyCollection<IContextProvider> EmptyContextProviders = new IContextProvider[0];
 
         /// <summary>
@@ -48,7 +49,7 @@ namespace RockLib.Logging
         /// </summary>
         /// <param name="name">The name of the logger.</param>
         /// <param name="level">The logging level of the logger.</param>
-        /// <param name="providers">A collection of <see cref="ILogProvider"/> objects used by this logger.</param>
+        /// <param name="logProviders">A collection of <see cref="ILogProvider"/> objects used by this logger.</param>
         /// <param name="isDisabled">A value indicating whether the logger is disabled.</param>
         /// <param name="isSynchronous">A value indicating whether the logger is synchrnous.</param>
         /// <param name="contextProviders">
@@ -57,7 +58,7 @@ namespace RockLib.Logging
         public Logger(
             string name = DefaultName,
             LogLevel level = LogLevel.NotSet,
-            IReadOnlyCollection<ILogProvider> providers = null,
+            [AlternateName("providers")] IReadOnlyCollection<ILogProvider> logProviders = null,
             bool isDisabled = false,
             bool isSynchronous = false,
             IReadOnlyCollection<IContextProvider> contextProviders = null)
@@ -67,12 +68,12 @@ namespace RockLib.Logging
 
             Name = name ?? DefaultName;
             Level = level;
-            Providers = providers ?? EmptyProviders;
+            LogProviders = logProviders ?? EmptyLogProviders;
             IsDisabled = isDisabled;
             IsSynchronous = isSynchronous;
             ContextProviders = contextProviders ?? EmptyContextProviders;
 
-            _canProcessLogs = !IsDisabled && Providers.Count > 0;
+            _canProcessLogs = !IsDisabled && LogProviders.Count > 0;
 
             if (!IsSynchronous)
             {
@@ -113,7 +114,7 @@ namespace RockLib.Logging
         /// <summary>
         /// Gets the collection of <see cref="ILogProvider"/> objects used by this logger.
         /// </summary>
-        public IReadOnlyCollection<ILogProvider> Providers { get; }
+        public IReadOnlyCollection<ILogProvider> LogProviders { get; }
 
         /// <summary>
         /// Gets a value indicating whether the logger is disabled.
@@ -188,7 +189,7 @@ namespace RockLib.Logging
             foreach (var contextProvider in ContextProviders)
                 contextProvider.AddContext(logEntry);
 
-            foreach (var logProvider in Providers)
+            foreach (var logProvider in LogProviders)
                 WriteToLogProvider(logEntry, logProvider);
         }
 
@@ -307,9 +308,9 @@ namespace RockLib.Logging
                     _trackingQueue.Dispose();
                 }
 
-                var providers = Providers?.GetEnumerator();
-                while (providers != null && providers.MoveNext())
-                    (providers.Current as IDisposable)?.Dispose();
+                var logProviders = LogProviders?.GetEnumerator();
+                while (logProviders != null && logProviders.MoveNext())
+                    (logProviders.Current as IDisposable)?.Dispose();
             }
         }
     }

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="RockLib.Configuration" Version="2.3.1" />
-    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.4.0" />
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.6.0" />
     <PackageReference Include="RockLib.Diagnostics" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds a collection of `IContextProvider` objects to the `Logger` class that are intended to modify the `LogEntry` objects passed to its `Log` method before the log providers send them.