### PR TITLE
Update RockLib.Logging to latest version

### DIFF
--- a/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
+++ b/RockLib.Logging.AspNetCore.Tests/AspNetExtensionsTests.cs
@@ -198,7 +198,7 @@ namespace RockLib.Logging.AspNetCore.Tests
                 ServiceCollection = new ServiceCollection()
             };
 
-            fakeBuilder.UseRockLibLogging("TestLogger1", defaultTypes: defaultTypes, reloadOnConfigChange: false, registerAspNetCoreLogger: true);
+            fakeBuilder.UseRockLibLogging("TestLogger1", defaultTypes: defaultTypes, registerAspNetCoreLogger: true);
 
             var logger = fakeBuilder.ServiceCollection[1].ImplementationFactory.Invoke(null);
             logger.Should().BeOfType<TestLogger>();
@@ -235,7 +235,7 @@ namespace RockLib.Logging.AspNetCore.Tests
                 ServiceCollection = new ServiceCollection()
             };
 
-            fakeBuilder.UseRockLibLogging("TestLogger2", defaultTypes: defaultTypes, valueConverters: valueConverters, reloadOnConfigChange: false, registerAspNetCoreLogger: true);
+            fakeBuilder.UseRockLibLogging("TestLogger2", defaultTypes: defaultTypes, valueConverters: valueConverters, registerAspNetCoreLogger: true);
 
             var logger = fakeBuilder.ServiceCollection[1].ImplementationFactory.Invoke(null);
             logger.Should().BeOfType<TestLogger>();
@@ -243,87 +243,6 @@ namespace RockLib.Logging.AspNetCore.Tests
             var testLogger = (TestLogger)logger;
             testLogger.Location.X.Should().Be(2);
             testLogger.Location.Y.Should().Be(3);
-        }
-
-        //[Fact]
-        //public void ResolverFunctionsProperly()
-        //{
-        //    if (!Config.IsLocked)
-        //    {
-        //        var dummy = Config.Root;
-        //    }
-
-        //    var dependency = new TestDependencyA();
-        //    var resolver = new Resolver(t => dependency, t => t == typeof(ITestDependency));
-
-        //    var defaultTypes = new DefaultTypes
-        //    {
-        //        { typeof(ILogger), typeof(TestLogger) }
-        //    };
-
-        //    var fakeBuilder = new FakeWebHostBuilder()
-        //    {
-        //        ServiceCollection = new ServiceCollection()
-        //    };
-
-        //    fakeBuilder.UseRockLibLogging("TestLogger3", defaultTypes: defaultTypes, resolver: resolver, reloadOnConfigChange: false, bypassAspNetCoreLogging: true);
-
-        //    var logger = fakeBuilder.ServiceCollection[1].ImplementationFactory.Invoke(null);
-        //    logger.Should().BeOfType<TestLogger>();
-
-        //    var testLogger = (TestLogger)logger;
-        //    testLogger.Dependency.Should().BeSameAs(dependency);
-        //}
-
-        [Fact]
-        public void ReloadOnConfigChangeTrueFunctionsProperly()
-        {
-            if (!Config.IsLocked)
-            {
-                var dummy = Config.Root;
-            }
-
-            var defaultTypes = new DefaultTypes
-            {
-                { typeof(ILogger), typeof(TestLogger) },
-                { typeof(ITestDependency), typeof(TestDependencyB) }
-            };
-
-            var fakeBuilder = new FakeWebHostBuilder()
-            {
-                ServiceCollection = new ServiceCollection()
-            };
-
-            fakeBuilder.UseRockLibLogging("TestLogger4", defaultTypes: defaultTypes, reloadOnConfigChange: true, registerAspNetCoreLogger: true);
-
-            var logger = fakeBuilder.ServiceCollection[1].ImplementationFactory.Invoke(null);
-            logger.Should().BeAssignableTo<ConfigReloadingProxy<ILogger>>();
-        }
-
-        [Fact]
-        public void ReloadOnConfigChangeFalseFunctionsProperly()
-        {
-            if (!Config.IsLocked)
-            {
-                var dummy = Config.Root;
-            }
-
-            var defaultTypes = new DefaultTypes
-            {
-                { typeof(ILogger), typeof(TestLogger) },
-                { typeof(ITestDependency), typeof(TestDependencyB) }
-            };
-
-            var fakeBuilder = new FakeWebHostBuilder()
-            {
-                ServiceCollection = new ServiceCollection()
-            };
-
-            fakeBuilder.UseRockLibLogging("TestLogger5", defaultTypes: defaultTypes, reloadOnConfigChange: false, registerAspNetCoreLogger: true);
-
-            IServiceProvider serviceProvider = null;
-            var logger = fakeBuilder.ServiceCollection[1].ImplementationFactory.Invoke(serviceProvider);
-            logger.Should().BeOfType<TestLogger>();
         }
 
         private class FakeWebHostBuilder : IWebHostBuilder

--- a/RockLib.Logging.AspNetCore.Tests/RockLib.Logging.AspNetCore.Tests.csproj
+++ b/RockLib.Logging.AspNetCore.Tests/RockLib.Logging.AspNetCore.Tests.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/RockLib.Logging.AspNetCore.Tests/RockLibLoggerProviderTests.cs
+++ b/RockLib.Logging.AspNetCore.Tests/RockLibLoggerProviderTests.cs
@@ -1,5 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -8,21 +9,22 @@ namespace RockLib.Logging.AspNetCore.Tests
     public class RockLibLoggerProviderTests
     {
         [Fact]
-        public void ConstructorSetsLogger()
+        public void ConstructorSetsCreateLogger()
         {
-            var logger = new Mock<ILogger>().Object;
+            Func<ILogger> createLogger = () => null;
 
-            var provider = new RockLibLoggerProvider(logger);
+            var provider = new RockLibLoggerProvider(createLogger);
 
-            provider.Logger.Should().BeSameAs(logger);
+            provider.CreateLogger.Should().BeSameAs(createLogger);
         }
 
         [Fact]
         public void CreateLoggerSucceeds()
         {
             var logger = new Mock<ILogger>().Object;
+            ILogger CreateLogger() => logger;
 
-            var provider = new RockLibLoggerProvider(logger);
+            ILoggerProvider provider = new RockLibLoggerProvider(CreateLogger);
 
             var rockLibLogger = (RockLibLogger)provider.CreateLogger("SomeCategory");
 

--- a/RockLib.Logging.AspNetCore.Tests/appsettings.json
+++ b/RockLib.Logging.AspNetCore.Tests/appsettings.json
@@ -1,9 +1,13 @@
 ﻿{
   "rocklib.logging": [
     {
-      "Name": "SomeRockLibName",
-      "Level": "Debug",
-      "Providers": { "type": "RockLib.Logging.ConsoleLogProvider, RockLib.Logging" }
+      "type": "RockLib.Logging.Logger, RockLib.Logging",
+      "reloadOnChange": "false",
+      "value": {
+        "Name": "SomeRockLibName",
+        "Level": "Debug",
+        "Providers": { "type": "RockLib.Logging.ConsoleLogProvider, RockLib.Logging" }
+      }
     },
     {
       "Name": "TestLogger1",

--- a/RockLib.Logging.AspNetCore/AspNetExtensions.cs
+++ b/RockLib.Logging.AspNetCore/AspNetExtensions.cs
@@ -49,7 +49,7 @@ namespace RockLib.Logging.AspNetCore
         /// <see cref="IServiceProvider"/>.
         /// </remarks>
         public static IWebHostBuilder UseRockLibLogging(this IWebHostBuilder builder, string rockLibLoggerName = Logger.DefaultName,
-            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null, bool reloadOnConfigChange = true,
+            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null,
             bool setConfigRoot = true, bool registerAspNetCoreLogger = false)
         {
             if (builder == null)
@@ -57,7 +57,7 @@ namespace RockLib.Logging.AspNetCore
 
             builder.ConfigureServices(services =>
             {
-                services.AddLoggerFromLoggerFactory(rockLibLoggerName, defaultTypes, valueConverters, reloadOnConfigChange, setConfigRoot);
+                services.AddLoggerFromLoggerFactory(rockLibLoggerName, defaultTypes, valueConverters, setConfigRoot);
                 if (registerAspNetCoreLogger)
                     services.AddRockLibLoggerProvider();
             });
@@ -98,7 +98,7 @@ namespace RockLib.Logging.AspNetCore
         }
 
         private static void AddLoggerFromLoggerFactory(this IServiceCollection services, string rockLibLoggerName, 
-            DefaultTypes defaultTypes, ValueConverters valueConverters, bool reloadOnConfigChange, bool setConfigRoot)
+            DefaultTypes defaultTypes, ValueConverters valueConverters, bool setConfigRoot)
         {
             services.AddSingleton<ILogProcessor, BackgroundLogProcessor>();
 
@@ -112,7 +112,7 @@ namespace RockLib.Logging.AspNetCore
 
                 var resolver = new Resolver(t => serviceProvider.GetService(t));
 
-                return LoggerFactory.Create(rockLibLoggerName, defaultTypes, valueConverters, resolver, reloadOnConfigChange);
+                return LoggerFactory.Create(rockLibLoggerName, defaultTypes, valueConverters, resolver, reloadOnConfigChange: false);
             });
         }
 

--- a/RockLib.Logging.AspNetCore/AspNetExtensions.cs
+++ b/RockLib.Logging.AspNetCore/AspNetExtensions.cs
@@ -40,7 +40,7 @@ namespace RockLib.Logging.AspNetCore
         /// If <see cref="LoggerFactory.SetConfiguration"/> is called directly, this value can be false.
         /// </param>
         /// <param name="registerAspNetCoreLogger">
-        /// Whether to bypass registering an <see cref="ILoggerProvider"/> with the DI system.
+        /// Whether to register a RockLib <see cref="ILoggerProvider"/> with the DI system.
         /// </param>
         /// <returns>IWebHostBuilder for chaining</returns>
         /// <remarks>
@@ -72,7 +72,7 @@ namespace RockLib.Logging.AspNetCore
         /// <param name="builder">The IWebHostBuilder being extended.</param>
         /// <param name="logger">The RockLib logger used for logging.</param>
         /// <param name="registerAspNetCoreLogger">
-        /// Whether to bypass registering an <see cref="ILoggerProvider"/> with the DI system.
+        /// Whether to register a RockLib <see cref="ILoggerProvider"/> with the DI system.
         /// </param>
         /// <returns>IWebHostBuilder for chaining</returns>
         /// <remarks>

--- a/RockLib.Logging.AspNetCore/AspNetExtensions.cs
+++ b/RockLib.Logging.AspNetCore/AspNetExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RockLib.Configuration;
 using RockLib.Configuration.ObjectFactory;
+using RockLib.Logging.LogProcessing;
 
 namespace RockLib.Logging.AspNetCore
 {
@@ -28,12 +29,6 @@ namespace RockLib.Logging.AspNetCore
         /// An object that defines custom converter functions that are used to convert string configuration
         /// values to a target type.
         /// </param>
-        /// <param name="resolver">
-        /// An object that can retrieve constructor parameter values that are not found in configuration. This
-        /// object is an adapter for dependency injection containers, such as Ninject, Unity, Autofac, or
-        /// StructureMap. Consider using the <see cref="Resolver"/> class for this parameter, as it supports
-        /// most depenedency injection containers.
-        /// </param>
         /// <param name="reloadOnConfigChange">
         /// Whether to create an instance of <see cref="ILogger"/> that automatically reloads itself when its
         /// configuration changes. Default is true.
@@ -44,7 +39,7 @@ namespace RockLib.Logging.AspNetCore
         /// the <see cref="LoggerFactory"/> uses <see cref="Config.Root"/> as the backing data source.
         /// If <see cref="LoggerFactory.SetConfiguration"/> is called directly, this value can be false.
         /// </param>
-        /// <param name="bypassAspNetCoreLogging">
+        /// <param name="registerAspNetCoreLogger">
         /// Whether to bypass registering an <see cref="ILoggerProvider"/> with the DI system.
         /// </param>
         /// <returns>IWebHostBuilder for chaining</returns>
@@ -54,16 +49,16 @@ namespace RockLib.Logging.AspNetCore
         /// <see cref="IServiceProvider"/>.
         /// </remarks>
         public static IWebHostBuilder UseRockLibLogging(this IWebHostBuilder builder, string rockLibLoggerName = Logger.DefaultName,
-            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null, IResolver resolver = null, bool reloadOnConfigChange = true,
-            bool setConfigRoot = true, bool bypassAspNetCoreLogging = false)
+            DefaultTypes defaultTypes = null, ValueConverters valueConverters = null, bool reloadOnConfigChange = true,
+            bool setConfigRoot = true, bool registerAspNetCoreLogger = false)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
             builder.ConfigureServices(services =>
             {
-                services.AddLoggerFromLoggerFactory(rockLibLoggerName, defaultTypes, valueConverters, resolver, reloadOnConfigChange, setConfigRoot);
-                if (!bypassAspNetCoreLogging)
+                services.AddLoggerFromLoggerFactory(rockLibLoggerName, defaultTypes, valueConverters, reloadOnConfigChange, setConfigRoot);
+                if (registerAspNetCoreLogger)
                     services.AddRockLibLoggerProvider();
             });
 
@@ -76,16 +71,16 @@ namespace RockLib.Logging.AspNetCore
         /// </summary>
         /// <param name="builder">The IWebHostBuilder being extended.</param>
         /// <param name="logger">The RockLib logger used for logging.</param>
-        /// <param name="bypassAspNetCoreLogging">
+        /// <param name="registerAspNetCoreLogger">
         /// Whether to bypass registering an <see cref="ILoggerProvider"/> with the DI system.
         /// </param>
         /// <returns>IWebHostBuilder for chaining</returns>
         /// <remarks>
-        /// This extension method, unlike the <see cref="UseRockLibLogging(IWebHostBuilder, string, DefaultTypes, ValueConverters, IResolver, bool, bool, bool)"/> overload, does not
+        /// This extension method, unlike the <see cref="UseRockLibLogging(IWebHostBuilder, string, DefaultTypes, ValueConverters, bool, bool, bool)"/> overload, does not
         /// have any side-effects. As such, applications using this extension method many need to call the
         /// <see cref="Config.SetRoot(IConfiguration)"/> method in the constructor of their <code>Startup</code> class.
         /// </remarks>
-        public static IWebHostBuilder UseRockLibLogging(this IWebHostBuilder builder, ILogger logger, bool bypassAspNetCoreLogging = false)
+        public static IWebHostBuilder UseRockLibLogging(this IWebHostBuilder builder, ILogger logger, bool registerAspNetCoreLogger = false)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
@@ -94,8 +89,8 @@ namespace RockLib.Logging.AspNetCore
 
             builder.ConfigureServices(services =>
             {
-                services.AddSingleton<ILogger>(logger);
-                if (!bypassAspNetCoreLogging)
+                services.AddSingleton(logger);
+                if (registerAspNetCoreLogger)
                     services.AddRockLibLoggerProvider();
             });
 
@@ -103,9 +98,11 @@ namespace RockLib.Logging.AspNetCore
         }
 
         private static void AddLoggerFromLoggerFactory(this IServiceCollection services, string rockLibLoggerName, 
-            DefaultTypes defaultTypes, ValueConverters valueConverters, IResolver resolver, bool reloadOnConfigChange, bool setConfigRoot)
+            DefaultTypes defaultTypes, ValueConverters valueConverters, bool reloadOnConfigChange, bool setConfigRoot)
         {
-            services.AddSingleton<ILogger>(serviceProvider =>
+            services.AddSingleton<ILogProcessor, BackgroundLogProcessor>();
+
+            services.AddTransient(serviceProvider =>
             {
                 if (setConfigRoot && !Config.IsLocked && Config.IsDefault)
                 {
@@ -113,7 +110,9 @@ namespace RockLib.Logging.AspNetCore
                     Config.SetRoot(configuration);
                 }
 
-                return LoggerFactory.GetCached(rockLibLoggerName, defaultTypes, valueConverters, resolver, reloadOnConfigChange);
+                var resolver = new Resolver(t => serviceProvider.GetService(t));
+
+                return LoggerFactory.Create(rockLibLoggerName, defaultTypes, valueConverters, resolver, reloadOnConfigChange);
             });
         }
 
@@ -121,8 +120,7 @@ namespace RockLib.Logging.AspNetCore
         {
             services.AddSingleton<ILoggerProvider>(serviceProvider =>
             {
-                var logger = serviceProvider.GetRequiredService<ILogger>();
-                return new RockLibLoggerProvider(logger);
+                return new RockLibLoggerProvider(() => serviceProvider.GetRequiredService<ILogger>());
             });
         }
     }

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -24,9 +24,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="RockLib.Logging" Version="2.0.0-alpha03" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
+    <PackageReference Include="RockLib.Logging" Version="2.0.0-alpha08" />
   </ItemGroup>
 
 </Project>

--- a/RockLib.Logging.AspNetCore/RockLibLoggerProvider.cs
+++ b/RockLib.Logging.AspNetCore/RockLibLoggerProvider.cs
@@ -1,23 +1,17 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 
 namespace RockLib.Logging.AspNetCore
 {
-    internal class RockLibLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider
+    internal class RockLibLoggerProvider : ILoggerProvider
     {
-        public RockLibLoggerProvider(ILogger logger)
-        {
-            Logger = logger;
-        }
+        public RockLibLoggerProvider(Func<ILogger> createLogger) => CreateLogger = createLogger;
 
-        public ILogger Logger { get; }
+        public Func<ILogger> CreateLogger { get; }
 
-        public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
-        {
-            return new RockLibLogger(Logger, categoryName);
-        }
+        Microsoft.Extensions.Logging.ILogger ILoggerProvider.CreateLogger(string categoryName) =>
+            new RockLibLogger(CreateLogger(), categoryName);
 
-        public void Dispose()
-        {
-        }
+        public void Dispose() {}
     }
 }


### PR DESCRIPTION
- Registers a singleton log processor in the "factory" UseRockLibLogging extension method. Also removes the resolver parameter.
- Renames/flips the bypassAspNetCoreLogging parameter to registerAspNetCoreLogger in both UseRockLibLogging extension methods.