### PR TITLE
Update Formatting.md

### DIFF
--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -4,14 +4,15 @@ By implementing the `RockLib.Logging.ILogFormatter` interface, defining the `For
 
 As an example, the following implementation of `ILogFormatter` will output `LogEntry.Message` followed by the Log`LogEntry.CreateTime`, with each separated by a hyphen.
 
-```C#
-   public class SimpleMessageFormatter : ILogFormatter
-    {
-        public string (LogEntry logEntry)
-        {
-            return $"{logEntry.Message} - {logEntry.CreateTime}";
-        }
-    }
+```csharp
+public class SimpleMessageFormatter : ILogFormatter
+{
+	public string Format(LogEntry logEntry)
+	{
+		// output Message - CreateTime (in ISO8601 format)
+		return $"{logEntry.Message} - {logEntry.CreateTime.ToString("o")}";
+	}
+}
 ```
 
 This would result in the following message being output by the consuming log provider when it is prompted to log:


### PR DESCRIPTION
Fix missing Format method name, correct CreateTime format to match example output

# Description

The documentation for create a custom formatter was missing a few details, this PR fixes:
- Fixes the missing `Format` method name
- Corrects the `CreateTime` format to match example output (ISO8601)

## Type of change

- [x] Documentation update
