### PR TITLE
Add RockLib.Logging.Moq project

### DIFF
--- a/RockLib.Logging.All.sln
+++ b/RockLib.Logging.All.sln
@@ -21,10 +21,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Logging.DependencyI
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Logging.DependencyInjection.Tests", "RockLib.Logging.DependencyInjection.Tests\RockLib.Logging.DependencyInjection.Tests.csproj", "{9B6FFB79-EFCE-40B9-8736-2B4167D75FBE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.GenericHost", "Example.GenericHost\Example.GenericHost.csproj", "{EA5BEAE2-CB99-4405-BD41-383F1F00DB74}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example.GenericHost", "Example.GenericHost\Example.GenericHost.csproj", "{EA5BEAE2-CB99-4405-BD41-383F1F00DB74}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Logging.Moq", "RockLib.Logging.Moq\RockLib.Logging.Moq.csproj", "{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		RockLib.Reflection.Optimized\RockLib.Reflection.Optimized.Shared\RockLib.Reflection.Optimized.Shared.projitems*{0f6f91d3-e6a9-4694-9598-d0cac6b115b3}*SharedItemsImports = 5
 		RockLib.Reflection.Optimized\RockLib.Reflection.Optimized.Shared\RockLib.Reflection.Optimized.Shared.projitems*{1f65cbb1-529e-407c-b7d6-8be5a59ebe14}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,6 +71,10 @@ Global
 		{EA5BEAE2-CB99-4405-BD41-383F1F00DB74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA5BEAE2-CB99-4405-BD41-383F1F00DB74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA5BEAE2-CB99-4405-BD41-383F1F00DB74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RockLib.Logging.All.sln
+++ b/RockLib.Logging.All.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example.GenericHost", "Exam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Logging.Moq", "RockLib.Logging.Moq\RockLib.Logging.Moq.csproj", "{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RockLib.Logging.Moq.Tests", "RockLib.Logging.Moq.Tests\RockLib.Logging.Moq.Tests.csproj", "{86EFB7D5-CF52-476D-BA9F-1D94778517C9}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		RockLib.Reflection.Optimized\RockLib.Reflection.Optimized.Shared\RockLib.Reflection.Optimized.Shared.projitems*{0f6f91d3-e6a9-4694-9598-d0cac6b115b3}*SharedItemsImports = 5
@@ -75,6 +77,10 @@ Global
 		{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1781C3A1-5CC5-4338-9D68-B86D7C4C7356}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86EFB7D5-CF52-476D-BA9F-1D94778517C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86EFB7D5-CF52-476D-BA9F-1D94778517C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86EFB7D5-CF52-476D-BA9F-1D94778517C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86EFB7D5-CF52-476D-BA9F-1D94778517C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RockLib.Logging.Moq.Tests/MockLoggerExtensionsTests.cs
+++ b/RockLib.Logging.Moq.Tests/MockLoggerExtensionsTests.cs
@@ -602,7 +602,7 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Info("Hello, world!");
 
-            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+            Action act = () => mockLogger.VerifyLog(Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
@@ -614,7 +614,7 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Info("Hello, world!");
 
-            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+            Action act = () => mockLogger.VerifyLog(Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
         }
@@ -624,9 +624,9 @@ namespace RockLib.Logging.Moq.Tests
         {
             var mockLogger = new MockLogger();
 
-            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+            mockLogger.Object.Info("Hello, world!");
 
-            Action act = () => mockLogger.VerifyLog(new { Foo = 123 }, Times.Once(), "My fail message");
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
@@ -636,9 +636,9 @@ namespace RockLib.Logging.Moq.Tests
         {
             var mockLogger = new MockLogger();
 
-            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+            mockLogger.Object.Info("Hello, world!");
 
-            Action act = () => mockLogger.VerifyLog(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
         }
@@ -650,13 +650,37 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
 
-            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+            Action act = () => mockLogger.VerifyLog(new { Foo = 123 }, Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
 
         [Fact(DisplayName = "VerifyLog method 3 throws MockException when criteria are not met")]
         public void VerifyLogMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyLog(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 4 verifies successfully when criteria are met")]
+        public void VerifyLogMethod4HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyLog method 4 throws MockException when criteria are not met")]
+        public void VerifyLogMethod4SadPath()
         {
             var mockLogger = new MockLogger();
 

--- a/RockLib.Logging.Moq.Tests/MockLoggerExtensionsTests.cs
+++ b/RockLib.Logging.Moq.Tests/MockLoggerExtensionsTests.cs
@@ -1,0 +1,670 @@
+﻿using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace RockLib.Logging.Moq.Tests
+{
+    public class MockLoggerExtensionsTests
+    {
+        [Fact(DisplayName = "SetupLogger method adds setups for Level and Name properties")]
+        public void SetupLoggerMethodHappyPath()
+        {
+            var mockLogger = new Mock<ILogger>();
+
+            mockLogger.SetupLogger(LogLevel.Warn, "TestLogger");
+
+            mockLogger.Setups.Should().HaveCount(2);
+            mockLogger.Object.Level.Should().Be(LogLevel.Warn);
+            mockLogger.Object.Name.Should().Be("TestLogger");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 1 verifies successfully when criteria are met")]
+        public void VerifyDebugMethod1HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!");
+
+            Action act = () => mockLogger.VerifyDebug(Times.Exactly(1), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 1 throws MockException when criteria are not met")]
+        public void VerifyDebugMethod1SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!");
+
+            Action act = () => mockLogger.VerifyDebug(Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 2 verifies successfully when criteria are met")]
+        public void VerifyDebugMethod2HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!");
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 2 throws MockException when criteria are not met")]
+        public void VerifyDebugMethod2SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!");
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 3 verifies successfully when criteria are met")]
+        public void VerifyDebugMethod3HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyDebug(new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 3 throws MockException when criteria are not met")]
+        public void VerifyDebugMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyDebug(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 4 verifies successfully when criteria are met")]
+        public void VerifyDebugMethod4HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 4 throws MockException when criteria are not met")]
+        public void VerifyDebugMethod4SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 1 verifies successfully when criteria are met")]
+        public void VerifyInfoMethod1HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!");
+
+            Action act = () => mockLogger.VerifyInfo(Times.Exactly(1), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 1 throws MockException when criteria are not met")]
+        public void VerifyInfoMethod1SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!");
+
+            Action act = () => mockLogger.VerifyInfo(Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 2 verifies successfully when criteria are met")]
+        public void VerifyInfoMethod2HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!");
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 2 throws MockException when criteria are not met")]
+        public void VerifyInfoMethod2SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!");
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 3 verifies successfully when criteria are met")]
+        public void VerifyInfoMethod3HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyInfo(new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 3 throws MockException when criteria are not met")]
+        public void VerifyInfoMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyInfo(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 4 verifies successfully when criteria are met")]
+        public void VerifyInfoMethod4HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 4 throws MockException when criteria are not met")]
+        public void VerifyInfoMethod4SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 1 verifies successfully when criteria are met")]
+        public void VerifyWarnMethod1HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!");
+
+            Action act = () => mockLogger.VerifyWarn(Times.Exactly(1), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 1 throws MockException when criteria are not met")]
+        public void VerifyWarnMethod1SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!");
+
+            Action act = () => mockLogger.VerifyWarn(Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 2 verifies successfully when criteria are met")]
+        public void VerifyWarnMethod2HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!");
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 2 throws MockException when criteria are not met")]
+        public void VerifyWarnMethod2SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!");
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 3 verifies successfully when criteria are met")]
+        public void VerifyWarnMethod3HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyWarn(new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 3 throws MockException when criteria are not met")]
+        public void VerifyWarnMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyWarn(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 4 verifies successfully when criteria are met")]
+        public void VerifyWarnMethod4HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 4 throws MockException when criteria are not met")]
+        public void VerifyWarnMethod4SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 1 verifies successfully when criteria are met")]
+        public void VerifyErrorMethod1HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!");
+
+            Action act = () => mockLogger.VerifyError(Times.Exactly(1), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyError method 1 throws MockException when criteria are not met")]
+        public void VerifyErrorMethod1SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!");
+
+            Action act = () => mockLogger.VerifyError(Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 2 verifies successfully when criteria are met")]
+        public void VerifyErrorMethod2HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!");
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyError method 2 throws MockException when criteria are not met")]
+        public void VerifyErrorMethod2SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!");
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 3 verifies successfully when criteria are met")]
+        public void VerifyErrorMethod3HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyError(new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyError method 3 throws MockException when criteria are not met")]
+        public void VerifyErrorMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyError(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 4 verifies successfully when criteria are met")]
+        public void VerifyErrorMethod4HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyError method 4 throws MockException when criteria are not met")]
+        public void VerifyErrorMethod4SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 1 verifies successfully when criteria are met")]
+        public void VerifyFatalMethod1HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!");
+
+            Action act = () => mockLogger.VerifyFatal(Times.Exactly(1), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 1 throws MockException when criteria are not met")]
+        public void VerifyFatalMethod1SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!");
+
+            Action act = () => mockLogger.VerifyFatal(Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 2 verifies successfully when criteria are met")]
+        public void VerifyFatalMethod2HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!");
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 2 throws MockException when criteria are not met")]
+        public void VerifyFatalMethod2SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!");
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 3 verifies successfully when criteria are met")]
+        public void VerifyFatalMethod3HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyFatal(new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 3 throws MockException when criteria are not met")]
+        public void VerifyFatalMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyFatal(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 4 verifies successfully when criteria are met")]
+        public void VerifyFatalMethod4HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 4 throws MockException when criteria are not met")]
+        public void VerifyFatalMethod4SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 1 verifies successfully when criteria are met")]
+        public void VerifyAuditMethod1HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!");
+
+            Action act = () => mockLogger.VerifyAudit(Times.Exactly(1), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 1 throws MockException when criteria are not met")]
+        public void VerifyAuditMethod1SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!");
+
+            Action act = () => mockLogger.VerifyAudit(Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 2 verifies successfully when criteria are met")]
+        public void VerifyAuditMethod2HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!");
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 2 throws MockException when criteria are not met")]
+        public void VerifyAuditMethod2SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!");
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 3 verifies successfully when criteria are met")]
+        public void VerifyAuditMethod3HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyAudit(new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 3 throws MockException when criteria are not met")]
+        public void VerifyAuditMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyAudit(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 4 verifies successfully when criteria are met")]
+        public void VerifyAuditMethod4HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 4 throws MockException when criteria are not met")]
+        public void VerifyAuditMethod4SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 1 verifies successfully when criteria are met")]
+        public void VerifyLogMethod1HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!");
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyLog method 1 throws MockException when criteria are not met")]
+        public void VerifyLogMethod1SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!");
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 2 verifies successfully when criteria are met")]
+        public void VerifyLogMethod2HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyLog(new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyLog method 2 throws MockException when criteria are not met")]
+        public void VerifyLogMethod2SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyLog(new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 3 verifies successfully when criteria are met")]
+        public void VerifyLogMethod3HappyPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Once(), "My fail message");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact(DisplayName = "VerifyLog method 3 throws MockException when criteria are not met")]
+        public void VerifyLogMethod3SadPath()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+    }
+}

--- a/RockLib.Logging.Moq.Tests/MockLoggerExtensionsTests.cs
+++ b/RockLib.Logging.Moq.Tests/MockLoggerExtensionsTests.cs
@@ -26,12 +26,12 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Debug("Hello, world!");
 
-            Action act = () => mockLogger.VerifyDebug(Times.Exactly(1), "My fail message");
+            Action act = () => mockLogger.VerifyDebug(Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyDebug method 1 throws MockException when criteria are not met")]
+        [Fact(DisplayName = "VerifyDebug method 1 throws MockException when criteria are not met - wrong Times")]
         public void VerifyDebugMethod1SadPath()
         {
             var mockLogger = new MockLogger();
@@ -55,8 +55,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyDebug method 2 throws MockException when criteria are not met")]
-        public void VerifyDebugMethod2SadPath()
+        [Fact(DisplayName = "VerifyDebug method 2 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyDebugMethod2SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -65,6 +65,18 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 2 throws MockException when criteria are not met - wrong message")]
+        public void VerifyDebugMethod2SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Good-bye, cruel world!");
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyDebug method 3 verifies successfully when criteria are met")]
@@ -79,8 +91,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyDebug method 3 throws MockException when criteria are not met")]
-        public void VerifyDebugMethod3SadPath()
+        [Fact(DisplayName = "VerifyDebug method 3 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyDebugMethod3SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -89,6 +101,30 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyDebug(new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 3 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyDebugMethod3SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyDebug(new { Foo = 456 }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 3 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyDebugMethod3SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = "foobar" });
+
+            Action act = () => mockLogger.VerifyDebug(new { Foo = "^foo$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyDebug method 4 verifies successfully when criteria are met")]
@@ -103,8 +139,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyDebug method 4 throws MockException when criteria are not met")]
-        public void VerifyDebugMethod4SadPath()
+        [Fact(DisplayName = "VerifyDebug method 4 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyDebugMethod4SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -115,6 +151,42 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
         }
 
+        [Fact(DisplayName = "VerifyDebug method 4 throws MockException when criteria are not met - wrong message")]
+        public void VerifyDebugMethod4SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Good-bye, cruel world!", new { Foo = 123, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 4 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyDebugMethod4SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = 456, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar ="^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyDebug method 4 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyDebugMethod4SadPath4()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Debug("Hello, world!", new { Foo = 123, Bar = "abcdefg" });
+
+            Action act = () => mockLogger.VerifyDebug(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
         [Fact(DisplayName = "VerifyInfo method 1 verifies successfully when criteria are met")]
         public void VerifyInfoMethod1HappyPath()
         {
@@ -122,12 +194,12 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Info("Hello, world!");
 
-            Action act = () => mockLogger.VerifyInfo(Times.Exactly(1), "My fail message");
+            Action act = () => mockLogger.VerifyInfo(Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyInfo method 1 throws MockException when criteria are not met")]
+        [Fact(DisplayName = "VerifyInfo method 1 throws MockException when criteria are not met - wrong Times")]
         public void VerifyInfoMethod1SadPath()
         {
             var mockLogger = new MockLogger();
@@ -151,8 +223,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyInfo method 2 throws MockException when criteria are not met")]
-        public void VerifyInfoMethod2SadPath()
+        [Fact(DisplayName = "VerifyInfo method 2 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyInfoMethod2SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -161,6 +233,18 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 2 throws MockException when criteria are not met - wrong message")]
+        public void VerifyInfoMethod2SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Good-bye, cruel world!");
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyInfo method 3 verifies successfully when criteria are met")]
@@ -175,8 +259,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyInfo method 3 throws MockException when criteria are not met")]
-        public void VerifyInfoMethod3SadPath()
+        [Fact(DisplayName = "VerifyInfo method 3 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyInfoMethod3SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -185,6 +269,30 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyInfo(new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 3 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyInfoMethod3SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyInfo(new { Foo = 456 }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 3 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyInfoMethod3SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = "foobar" });
+
+            Action act = () => mockLogger.VerifyInfo(new { Foo = "^foo$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyInfo method 4 verifies successfully when criteria are met")]
@@ -199,8 +307,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyInfo method 4 throws MockException when criteria are not met")]
-        public void VerifyInfoMethod4SadPath()
+        [Fact(DisplayName = "VerifyInfo method 4 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyInfoMethod4SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -211,6 +319,42 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
         }
 
+        [Fact(DisplayName = "VerifyInfo method 4 throws MockException when criteria are not met - wrong message")]
+        public void VerifyInfoMethod4SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Good-bye, cruel world!", new { Foo = 123, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 4 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyInfoMethod4SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 456, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyInfo method 4 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyInfoMethod4SadPath4()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123, Bar = "abcdefg" });
+
+            Action act = () => mockLogger.VerifyInfo(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
         [Fact(DisplayName = "VerifyWarn method 1 verifies successfully when criteria are met")]
         public void VerifyWarnMethod1HappyPath()
         {
@@ -218,12 +362,12 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Warn("Hello, world!");
 
-            Action act = () => mockLogger.VerifyWarn(Times.Exactly(1), "My fail message");
+            Action act = () => mockLogger.VerifyWarn(Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyWarn method 1 throws MockException when criteria are not met")]
+        [Fact(DisplayName = "VerifyWarn method 1 throws MockException when criteria are not met - wrong Times")]
         public void VerifyWarnMethod1SadPath()
         {
             var mockLogger = new MockLogger();
@@ -247,8 +391,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyWarn method 2 throws MockException when criteria are not met")]
-        public void VerifyWarnMethod2SadPath()
+        [Fact(DisplayName = "VerifyWarn method 2 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyWarnMethod2SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -257,6 +401,18 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 2 throws MockException when criteria are not met - wrong message")]
+        public void VerifyWarnMethod2SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Good-bye, cruel world!");
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyWarn method 3 verifies successfully when criteria are met")]
@@ -271,8 +427,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyWarn method 3 throws MockException when criteria are not met")]
-        public void VerifyWarnMethod3SadPath()
+        [Fact(DisplayName = "VerifyWarn method 3 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyWarnMethod3SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -281,6 +437,30 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyWarn(new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 3 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyWarnMethod3SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyWarn(new { Foo = 456 }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 3 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyWarnMethod3SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = "foobar" });
+
+            Action act = () => mockLogger.VerifyWarn(new { Foo = "^foo$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyWarn method 4 verifies successfully when criteria are met")]
@@ -295,8 +475,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyWarn method 4 throws MockException when criteria are not met")]
-        public void VerifyWarnMethod4SadPath()
+        [Fact(DisplayName = "VerifyWarn method 4 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyWarnMethod4SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -307,6 +487,42 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
         }
 
+        [Fact(DisplayName = "VerifyWarn method 4 throws MockException when criteria are not met - wrong message")]
+        public void VerifyWarnMethod4SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Good-bye, cruel world!", new { Foo = 123, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 4 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyWarnMethod4SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = 456, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyWarn method 4 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyWarnMethod4SadPath4()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Warn("Hello, world!", new { Foo = 123, Bar = "abcdefg" });
+
+            Action act = () => mockLogger.VerifyWarn(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
         [Fact(DisplayName = "VerifyError method 1 verifies successfully when criteria are met")]
         public void VerifyErrorMethod1HappyPath()
         {
@@ -314,12 +530,12 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Error("Hello, world!");
 
-            Action act = () => mockLogger.VerifyError(Times.Exactly(1), "My fail message");
+            Action act = () => mockLogger.VerifyError(Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyError method 1 throws MockException when criteria are not met")]
+        [Fact(DisplayName = "VerifyError method 1 throws MockException when criteria are not met - wrong Times")]
         public void VerifyErrorMethod1SadPath()
         {
             var mockLogger = new MockLogger();
@@ -343,8 +559,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyError method 2 throws MockException when criteria are not met")]
-        public void VerifyErrorMethod2SadPath()
+        [Fact(DisplayName = "VerifyError method 2 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyErrorMethod2SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -353,6 +569,18 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 2 throws MockException when criteria are not met - wrong message")]
+        public void VerifyErrorMethod2SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Good-bye, cruel world!");
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyError method 3 verifies successfully when criteria are met")]
@@ -367,8 +595,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyError method 3 throws MockException when criteria are not met")]
-        public void VerifyErrorMethod3SadPath()
+        [Fact(DisplayName = "VerifyError method 3 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyErrorMethod3SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -377,6 +605,30 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyError(new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 3 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyErrorMethod3SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyError(new { Foo = 456 }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 3 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyErrorMethod3SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = "foobar" });
+
+            Action act = () => mockLogger.VerifyError(new { Foo = "^foo$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyError method 4 verifies successfully when criteria are met")]
@@ -391,8 +643,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyError method 4 throws MockException when criteria are not met")]
-        public void VerifyErrorMethod4SadPath()
+        [Fact(DisplayName = "VerifyError method 4 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyErrorMethod4SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -403,6 +655,42 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
         }
 
+        [Fact(DisplayName = "VerifyError method 4 throws MockException when criteria are not met - wrong message")]
+        public void VerifyErrorMethod4SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Good-bye, cruel world!", new { Foo = 123, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 4 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyErrorMethod4SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = 456, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyError method 4 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyErrorMethod4SadPath4()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Error("Hello, world!", new { Foo = 123, Bar = "abcdefg" });
+
+            Action act = () => mockLogger.VerifyError(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
         [Fact(DisplayName = "VerifyFatal method 1 verifies successfully when criteria are met")]
         public void VerifyFatalMethod1HappyPath()
         {
@@ -410,12 +698,12 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Fatal("Hello, world!");
 
-            Action act = () => mockLogger.VerifyFatal(Times.Exactly(1), "My fail message");
+            Action act = () => mockLogger.VerifyFatal(Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyFatal method 1 throws MockException when criteria are not met")]
+        [Fact(DisplayName = "VerifyFatal method 1 throws MockException when criteria are not met - wrong Times")]
         public void VerifyFatalMethod1SadPath()
         {
             var mockLogger = new MockLogger();
@@ -439,8 +727,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyFatal method 2 throws MockException when criteria are not met")]
-        public void VerifyFatalMethod2SadPath()
+        [Fact(DisplayName = "VerifyFatal method 2 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyFatalMethod2SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -449,6 +737,18 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 2 throws MockException when criteria are not met - wrong message")]
+        public void VerifyFatalMethod2SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Good-bye, cruel world!");
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyFatal method 3 verifies successfully when criteria are met")]
@@ -463,8 +763,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyFatal method 3 throws MockException when criteria are not met")]
-        public void VerifyFatalMethod3SadPath()
+        [Fact(DisplayName = "VerifyFatal method 3 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyFatalMethod3SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -473,6 +773,30 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyFatal(new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 3 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyFatalMethod3SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyFatal(new { Foo = 456 }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 3 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyFatalMethod3SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = "foobar" });
+
+            Action act = () => mockLogger.VerifyFatal(new { Foo = "^foo$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyFatal method 4 verifies successfully when criteria are met")]
@@ -487,8 +811,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyFatal method 4 throws MockException when criteria are not met")]
-        public void VerifyFatalMethod4SadPath()
+        [Fact(DisplayName = "VerifyFatal method 4 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyFatalMethod4SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -499,6 +823,42 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
         }
 
+        [Fact(DisplayName = "VerifyFatal method 4 throws MockException when criteria are not met - wrong message")]
+        public void VerifyFatalMethod4SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Good-bye, cruel world!", new { Foo = 123, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 4 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyFatalMethod4SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = 456, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyFatal method 4 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyFatalMethod4SadPath4()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Fatal("Hello, world!", new { Foo = 123, Bar = "abcdefg" });
+
+            Action act = () => mockLogger.VerifyFatal(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
         [Fact(DisplayName = "VerifyAudit method 1 verifies successfully when criteria are met")]
         public void VerifyAuditMethod1HappyPath()
         {
@@ -506,12 +866,12 @@ namespace RockLib.Logging.Moq.Tests
 
             mockLogger.Object.Audit("Hello, world!");
 
-            Action act = () => mockLogger.VerifyAudit(Times.Exactly(1), "My fail message");
+            Action act = () => mockLogger.VerifyAudit(Times.Once(), "My fail message");
 
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyAudit method 1 throws MockException when criteria are not met")]
+        [Fact(DisplayName = "VerifyAudit method 1 throws MockException when criteria are not met - wrong Times")]
         public void VerifyAuditMethod1SadPath()
         {
             var mockLogger = new MockLogger();
@@ -535,8 +895,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyAudit method 2 throws MockException when criteria are not met")]
-        public void VerifyAuditMethod2SadPath()
+        [Fact(DisplayName = "VerifyAudit method 2 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyAuditMethod2SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -545,6 +905,18 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 2 throws MockException when criteria are not met - wrong message")]
+        public void VerifyAuditMethod2SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Good-bye, cruel world!");
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyAudit method 3 verifies successfully when criteria are met")]
@@ -559,8 +931,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyAudit method 3 throws MockException when criteria are not met")]
-        public void VerifyAuditMethod3SadPath()
+        [Fact(DisplayName = "VerifyAudit method 3 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyAuditMethod3SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -569,6 +941,30 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyAudit(new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 3 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyAuditMethod3SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyAudit(new { Foo = 456 }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 3 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyAuditMethod3SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = "foobar" });
+
+            Action act = () => mockLogger.VerifyAudit(new { Foo = "^foo$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyAudit method 4 verifies successfully when criteria are met")]
@@ -583,8 +979,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyAudit method 4 throws MockException when criteria are not met")]
-        public void VerifyAuditMethod4SadPath()
+        [Fact(DisplayName = "VerifyAudit method 4 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyAuditMethod4SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -593,6 +989,42 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 4 throws MockException when criteria are not met - wrong message")]
+        public void VerifyAuditMethod4SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Good-bye, cruel world!", new { Foo = 123, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 4 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyAuditMethod4SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = 456, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyAudit method 4 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyAuditMethod4SadPath4()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Audit("Hello, world!", new { Foo = 123, Bar = "abcdefg" });
+
+            Action act = () => mockLogger.VerifyAudit(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyLog method 1 verifies successfully when criteria are met")]
@@ -607,7 +1039,7 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyLog method 1 throws MockException when criteria are not met")]
+        [Fact(DisplayName = "VerifyLog method 1 throws MockException when criteria are not met - wrong Times")]
         public void VerifyLogMethod1SadPath()
         {
             var mockLogger = new MockLogger();
@@ -631,8 +1063,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyLog method 2 throws MockException when criteria are not met")]
-        public void VerifyLogMethod2SadPath()
+        [Fact(DisplayName = "VerifyLog method 2 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyLogMethod2SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -641,6 +1073,18 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 2 throws MockException when criteria are not met - wrong message")]
+        public void VerifyLogMethod2SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Good-bye, cruel world!");
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyLog method 3 verifies successfully when criteria are met")]
@@ -655,8 +1099,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyLog method 3 throws MockException when criteria are not met")]
-        public void VerifyLogMethod3SadPath()
+        [Fact(DisplayName = "VerifyLog method 3 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyLogMethod3SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -665,6 +1109,30 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyLog(new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 3 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyLogMethod3SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123 });
+
+            Action act = () => mockLogger.VerifyLog(new { Foo = 456 }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 3 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyLogMethod3SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = "foobar" });
+
+            Action act = () => mockLogger.VerifyLog(new { Foo = "^foo$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
 
         [Fact(DisplayName = "VerifyLog method 4 verifies successfully when criteria are met")]
@@ -679,8 +1147,8 @@ namespace RockLib.Logging.Moq.Tests
             act.Should().NotThrow();
         }
 
-        [Fact(DisplayName = "VerifyLog method 4 throws MockException when criteria are not met")]
-        public void VerifyLogMethod4SadPath()
+        [Fact(DisplayName = "VerifyLog method 4 throws MockException when criteria are not met - wrong Times")]
+        public void VerifyLogMethod4SadPath1()
         {
             var mockLogger = new MockLogger();
 
@@ -689,6 +1157,42 @@ namespace RockLib.Logging.Moq.Tests
             Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123 }, Times.Exactly(2), "My fail message");
 
             act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock exactly 2 times, but was 1 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 4 throws MockException when criteria are not met - wrong message")]
+        public void VerifyLogMethod4SadPath2()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Good-bye, cruel world!", new { Foo = 123, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 4 throws MockException when criteria are not met - wrong extended property")]
+        public void VerifyLogMethod4SadPath3()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 456, Bar = "abc" });
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
+        }
+
+        [Fact(DisplayName = "VerifyLog method 4 throws MockException when criteria are not met - wrong string extended property")]
+        public void VerifyLogMethod4SadPath4()
+        {
+            var mockLogger = new MockLogger();
+
+            mockLogger.Object.Info("Hello, world!", new { Foo = 123, Bar = "abcdefg" });
+
+            Action act = () => mockLogger.VerifyLog(@"(?i)hello,\s+world[.!?]", new { Foo = 123, Bar = "^abc$" }, Times.Once(), "My fail message");
+
+            act.Should().ThrowExactly<MockException>().WithMessage("*My fail message*Expected invocation on the mock once, but was 0 times*");
         }
     }
 }

--- a/RockLib.Logging.Moq.Tests/MockLoggerTests.cs
+++ b/RockLib.Logging.Moq.Tests/MockLoggerTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace RockLib.Logging.Moq.Tests
+{
+    public class MockLoggerTests
+    {
+        [Fact(DisplayName = "Constructor adds setups for Level and Name properties")]
+        public void ConstructorHappyPath()
+        {
+            var mockLogger = new MockLogger(LogLevel.Info, "TestLogger", MockBehavior.Strict);
+
+            mockLogger.Setups.Should().HaveCount(2);
+            mockLogger.Behavior.Should().Be(MockBehavior.Strict);
+            mockLogger.Object.Level.Should().Be(LogLevel.Info);
+            mockLogger.Object.Name.Should().Be("TestLogger");
+        }
+    }
+}

--- a/RockLib.Logging.Moq.Tests/RockLib.Logging.Moq.Tests.csproj
+++ b/RockLib.Logging.Moq.Tests/RockLib.Logging.Moq.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockLib.Logging.Moq\RockLib.Logging.Moq.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RockLib.Logging.Moq/MockLogger.cs
+++ b/RockLib.Logging.Moq/MockLogger.cs
@@ -1,0 +1,13 @@
+﻿using Moq;
+
+namespace RockLib.Logging.Moq
+{
+    public class MockLogger : Mock<ILogger>
+    {
+        public MockLogger(string name = "default", LogLevel level = LogLevel.Debug, MockBehavior behavior = MockBehavior.Default)
+            : base(behavior)
+        {
+            this.Setup(name, level);
+        }
+    }
+}

--- a/RockLib.Logging.Moq/MockLogger.cs
+++ b/RockLib.Logging.Moq/MockLogger.cs
@@ -2,8 +2,17 @@
 
 namespace RockLib.Logging.Moq
 {
+    /// <summary>
+    /// Provides a mock implementation of <see cref="ILogger"/>.
+    /// </summary>
     public class MockLogger : Mock<ILogger>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockLogger"/> class.
+        /// </summary>
+        /// <param name="level">The level of the mock logger.</param>
+        /// <param name="name">The name of the mock logger.</param>
+        /// <param name="behavior">The behavior of the mock.</param>
         public MockLogger(LogLevel level = LogLevel.Debug, string name = Logger.DefaultName, MockBehavior behavior = MockBehavior.Default)
             : base(behavior)
         {

--- a/RockLib.Logging.Moq/MockLogger.cs
+++ b/RockLib.Logging.Moq/MockLogger.cs
@@ -4,10 +4,10 @@ namespace RockLib.Logging.Moq
 {
     public class MockLogger : Mock<ILogger>
     {
-        public MockLogger(string name = "default", LogLevel level = LogLevel.Debug, MockBehavior behavior = MockBehavior.Default)
+        public MockLogger(LogLevel level = LogLevel.Debug, string name = Logger.DefaultName, MockBehavior behavior = MockBehavior.Default)
             : base(behavior)
         {
-            this.Setup(name, level);
+            this.Setup(level, name);
         }
     }
 }

--- a/RockLib.Logging.Moq/MockLogger.cs
+++ b/RockLib.Logging.Moq/MockLogger.cs
@@ -16,7 +16,7 @@ namespace RockLib.Logging.Moq
         public MockLogger(LogLevel level = LogLevel.Debug, string name = Logger.DefaultName, MockBehavior behavior = MockBehavior.Default)
             : base(behavior)
         {
-            this.Setup(level, name);
+            this.SetupLogger(level, name);
         }
     }
 }

--- a/RockLib.Logging.Moq/MockLoggerExtensions.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.cs
@@ -20,7 +20,7 @@ namespace RockLib.Logging.Moq
         /// <param name="level">The level of the mock logger.</param>
         /// <param name="name">The name of the mock logger.</param>
         /// <returns>The same mock logger.</returns>
-        public static Mock<ILogger> Setup(this Mock<ILogger> mockLogger, LogLevel level = LogLevel.Debug, string name = Logger.DefaultName)
+        public static Mock<ILogger> SetupLogger(this Mock<ILogger> mockLogger, LogLevel level = LogLevel.Debug, string name = Logger.DefaultName)
         {
             mockLogger.Setup(m => m.Level).Returns(level);
             mockLogger.Setup(m => m.Name).Returns(name ?? Logger.DefaultName);

--- a/RockLib.Logging.Moq/MockLoggerExtensions.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.cs
@@ -130,12 +130,29 @@ namespace RockLib.Logging.Moq
         public static void VerifyAudit(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(LogLevel.Audit, times, failMessage);
 
-        private static void VerifyLog(this Mock<ILogger> mockLogger, LogLevel logLevel, Times? times, string failMessage)
+        /// <summary>
+        /// Verifies that the mock logger logged at any <see cref="LogLevel"/> the number of times specified
+        /// by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log at any <see cref="LogLevel"/> the number of times specified by
+        /// <paramref name="times"/>.
+        /// </exception>
+        public static void VerifyLog(this Mock<ILogger> mockLogger, Times? times, string failMessage) =>
+            mockLogger.VerifyLog((LogLevel?)null, times, failMessage);
+
+        private static void VerifyLog(this Mock<ILogger> mockLogger, LogLevel? logLevel, Times? times, string failMessage)
         {
             if (mockLogger == null)
                 throw new ArgumentNullException(nameof(mockLogger));
 
-            Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry => logEntry.Level == logLevel;
+            Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry => !logLevel.HasValue || logEntry.Level == logLevel.Value;
 
             mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
                 times ?? Times.Once(), failMessage);

--- a/RockLib.Logging.Moq/MockLoggerExtensions.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.cs
@@ -6,8 +6,20 @@ using Moq;
 
 namespace RockLib.Logging.Moq
 {
+    /// <summary>
+    /// Provides extension methods for setting up and verifying instances of <see cref="Mock{T}"/> of type
+    /// <see cref="ILogger"/>.
+    /// </summary>
     public static class MockLoggerExtensions
     {
+        /// <summary>
+        /// Specifies setups on the mock logger for the <see cref="ILogger.Level"/> and <see cref="ILogger.Name"/>
+        /// properties.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to perform setups on.</param>
+        /// <param name="level">The level of the mock logger.</param>
+        /// <param name="name">The name of the mock logger.</param>
+        /// <returns>The same mock logger.</returns>
         public static Mock<ILogger> Setup(this Mock<ILogger> mockLogger, LogLevel level = LogLevel.Debug, string name = Logger.DefaultName)
         {
             mockLogger.Setup(m => m.Level).Returns(level);
@@ -16,21 +28,105 @@ namespace RockLib.Logging.Moq
             return mockLogger;
         }
 
+        /// <summary>
+        /// Verifies that the mock logger logged at <see cref="LogLevel.Debug"/> the number of times specified
+        /// by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log at <see cref="LogLevel.Debug"/> the number of times specified by
+        /// <paramref name="times"/>.
+        /// </exception>
         public static void VerifyDebug(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(LogLevel.Debug, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged at <see cref="LogLevel.Info"/> the number of times specified
+        /// by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log at <see cref="LogLevel.Info"/> the number of times specified by
+        /// <paramref name="times"/>.
+        /// </exception>
         public static void VerifyInfo(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(LogLevel.Info, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged at <see cref="LogLevel.Warn"/> the number of times specified
+        /// by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log at <see cref="LogLevel.Warn"/> the number of times specified by
+        /// <paramref name="times"/>.
+        /// </exception>
         public static void VerifyWarn(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(LogLevel.Warn, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged at <see cref="LogLevel.Error"/> the number of times specified
+        /// by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log at <see cref="LogLevel.Error"/> the number of times specified by
+        /// <paramref name="times"/>.
+        /// </exception>
         public static void VerifyError(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(LogLevel.Error, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged at <see cref="LogLevel.Fatal"/> the number of times specified
+        /// by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log at <see cref="LogLevel.Fatal"/> the number of times specified by
+        /// <paramref name="times"/>.
+        /// </exception>
         public static void VerifyFatal(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(LogLevel.Fatal, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged at <see cref="LogLevel.Audit"/> the number of times specified
+        /// by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log at <see cref="LogLevel.Audit"/> the number of times specified by
+        /// <paramref name="times"/>.
+        /// </exception>
         public static void VerifyAudit(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(LogLevel.Audit, times, failMessage);
 
@@ -45,30 +141,156 @@ namespace RockLib.Logging.Moq
                 times ?? Times.Once(), failMessage);
         }
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, LogLevel.Debug, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, LogLevel.Info, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, LogLevel.Warn, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, LogLevel.Error, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, LogLevel.Fatal, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// at <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, LogLevel.Audit, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// at any <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// at any <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, null, times, failMessage);
@@ -91,30 +313,163 @@ namespace RockLib.Logging.Moq
                 times ?? Times.Once(), failMessage);
         }
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the extended properties specified by
+        /// <paramref name="extendedProperties"/> at <see cref="LogLevel.Debug"/> the number of times
+        /// specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the extended properties specified by <paramref name="extendedProperties"/>
+        /// at <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyDebug(this Mock<ILogger> mockLogger, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, LogLevel.Debug, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the extended properties specified by
+        /// <paramref name="extendedProperties"/> at <see cref="LogLevel.Info"/> the number of times
+        /// specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the extended properties specified by <paramref name="extendedProperties"/>
+        /// at <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyInfo(this Mock<ILogger> mockLogger, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, LogLevel.Info, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the extended properties specified by
+        /// <paramref name="extendedProperties"/> at <see cref="LogLevel.Warn"/> the number of times
+        /// specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the extended properties specified by <paramref name="extendedProperties"/>
+        /// at <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyWarn(this Mock<ILogger> mockLogger, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, LogLevel.Warn, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the extended properties specified by
+        /// <paramref name="extendedProperties"/> at <see cref="LogLevel.Error"/> the number of times
+        /// specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the extended properties specified by <paramref name="extendedProperties"/>
+        /// at <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyError(this Mock<ILogger> mockLogger, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, LogLevel.Error, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the extended properties specified by
+        /// <paramref name="extendedProperties"/> at <see cref="LogLevel.Fatal"/> the number of times
+        /// specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the extended properties specified by <paramref name="extendedProperties"/>
+        /// at <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyFatal(this Mock<ILogger> mockLogger, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, LogLevel.Fatal, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the extended properties specified by
+        /// <paramref name="extendedProperties"/> at <see cref="LogLevel.Audit"/> the number of times
+        /// specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the extended properties specified by <paramref name="extendedProperties"/>
+        /// at <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyAudit(this Mock<ILogger> mockLogger, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, LogLevel.Audit, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the extended properties specified by
+        /// <paramref name="extendedProperties"/> at any <see cref="LogLevel"/> the number of times
+        /// specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the extended properties specified by <paramref name="extendedProperties"/>
+        /// at any <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyLog(this Mock<ILogger> mockLogger, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, null, times, failMessage);
@@ -160,30 +515,198 @@ namespace RockLib.Logging.Moq
                 times ?? Times.Once(), failMessage);
         }
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Debug, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Info, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Warn, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Error, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Fatal, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at
+        /// <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Audit, times, failMessage);
 
+        /// <summary>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at any
+        /// <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
+        /// </summary>
+        /// <param name="mockLogger">The mock logger to verify.</param>
+        /// <param name="messagePattern">
+        /// A regular expression pattern that the message of a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="extendedProperties">
+        /// An object representing the extended properties that a log must match in order for successful
+        /// verification to occur.
+        /// </param>
+        /// <param name="times">
+        /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
+        /// <see cref="Times.Once()"/> is used.
+        /// </param>
+        /// <param name="failMessage">Message to show if verification fails.</param>
+        /// <exception cref="MockException">
+        /// The logger did not log with the message specified by <paramref name="messagePattern"/>
+        /// and the extended properties specified by <paramref name="extendedProperties"/> at any
+        /// <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
+        /// </exception>
         public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, null, times, failMessage);

--- a/RockLib.Logging.Moq/MockLoggerExtensions.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.cs
@@ -8,10 +8,10 @@ namespace RockLib.Logging.Moq
 {
     public static class MockLoggerExtensions
     {
-        public static Mock<ILogger> Setup(this Mock<ILogger> mockLogger, string name, LogLevel level)
+        public static Mock<ILogger> Setup(this Mock<ILogger> mockLogger, LogLevel level = LogLevel.Debug, string name = Logger.DefaultName)
         {
-            mockLogger.Setup(m => m.Name).Returns(name);
             mockLogger.Setup(m => m.Level).Returns(level);
+            mockLogger.Setup(m => m.Name).Returns(name ?? Logger.DefaultName);
 
             return mockLogger;
         }

--- a/RockLib.Logging.Moq/MockLoggerExtensions.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.cs
@@ -69,8 +69,12 @@ namespace RockLib.Logging.Moq
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, LogLevel.Audit, times, failMessage);
 
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, null, times, failMessage);
+
         private static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern,
-            LogLevel logLevel, Times? times, string failMessage)
+            LogLevel? logLevel, Times? times, string failMessage)
         {
             if (mockLogger == null)
                 throw new ArgumentNullException(nameof(mockLogger));
@@ -80,7 +84,8 @@ namespace RockLib.Logging.Moq
             var messageRegex = new Regex(messagePattern);
 
             Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry =>
-                messageRegex.IsMatch(logEntry.Message) && logEntry.Level == logLevel;
+                messageRegex.IsMatch(logEntry.Message)
+                && (!logLevel.HasValue || logEntry.Level == logLevel.Value);
 
             mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
                 times ?? Times.Once(), failMessage);
@@ -110,8 +115,12 @@ namespace RockLib.Logging.Moq
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(extendedProperties, LogLevel.Audit, times, failMessage);
 
+        public static void VerifyLog(this Mock<ILogger> mockLogger, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(extendedProperties, null, times, failMessage);
+
         private static void VerifyLog(this Mock<ILogger> mockLogger, object extendedProperties,
-            LogLevel logLevel, Times? times, string failMessage)
+            LogLevel? logLevel, Times? times, string failMessage)
         {
             if (mockLogger == null)
                 throw new ArgumentNullException(nameof(mockLogger));
@@ -144,7 +153,7 @@ namespace RockLib.Logging.Moq
             };
 
             Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry =>
-                logEntry.Level == logLevel
+                (!logLevel.HasValue || logEntry.Level == logLevel.Value)
                 && hasMatchingExtendedProperties(logEntry);
 
             mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
@@ -175,8 +184,12 @@ namespace RockLib.Logging.Moq
             Times? times = null, string failMessage = null) =>
             mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Audit, times, failMessage);
 
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, extendedProperties, null, times, failMessage);
+
         private static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
-            LogLevel logLevel, Times? times, string failMessage)
+            LogLevel? logLevel, Times? times, string failMessage)
         {
             if (mockLogger == null)
                 throw new ArgumentNullException(nameof(mockLogger));
@@ -214,7 +227,7 @@ namespace RockLib.Logging.Moq
 
             Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry =>
                 messageRegex.IsMatch(logEntry.Message)
-                && logEntry.Level == logLevel
+                && (!logLevel.HasValue || logEntry.Level == logLevel.Value)
                 && hasMatchingExtendedProperties(logEntry);
 
             mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),

--- a/RockLib.Logging.Moq/MockLoggerExtensions.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using Moq;
+
+namespace RockLib.Logging.Moq
+{
+    public static class MockLoggerExtensions
+    {
+        public static Mock<ILogger> Setup(this Mock<ILogger> mockLogger, string name, LogLevel level)
+        {
+            mockLogger.Setup(m => m.Name).Returns(name);
+            mockLogger.Setup(m => m.Level).Returns(level);
+
+            return mockLogger;
+        }
+
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(LogLevel.Debug, times, failMessage);
+
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(LogLevel.Info, times, failMessage);
+
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(LogLevel.Warn, times, failMessage);
+
+        public static void VerifyError(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(LogLevel.Error, times, failMessage);
+
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(LogLevel.Fatal, times, failMessage);
+
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(LogLevel.Audit, times, failMessage);
+
+        private static void VerifyLog(this Mock<ILogger> mockLogger, LogLevel logLevel, Times? times, string failMessage)
+        {
+            if (mockLogger == null)
+                throw new ArgumentNullException(nameof(mockLogger));
+
+            Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry => logEntry.Level == logLevel;
+
+            mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
+                times ?? Times.Once(), failMessage);
+        }
+
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, LogLevel.Debug, times, failMessage);
+
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, LogLevel.Info, times, failMessage);
+
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, LogLevel.Warn, times, failMessage);
+
+        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, LogLevel.Error, times, failMessage);
+
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, LogLevel.Fatal, times, failMessage);
+
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, LogLevel.Audit, times, failMessage);
+
+        private static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern,
+            LogLevel logLevel, Times? times, string failMessage)
+        {
+            if (mockLogger == null)
+                throw new ArgumentNullException(nameof(mockLogger));
+            if (messagePattern == null)
+                throw new ArgumentNullException(nameof(messagePattern));
+
+            var messageRegex = new Regex(messagePattern);
+
+            Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry =>
+                messageRegex.IsMatch(logEntry.Message) && logEntry.Level == logLevel;
+
+            mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
+                times ?? Times.Once(), failMessage);
+        }
+
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(extendedProperties, LogLevel.Debug, times, failMessage);
+
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(extendedProperties, LogLevel.Info, times, failMessage);
+
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(extendedProperties, LogLevel.Warn, times, failMessage);
+
+        public static void VerifyError(this Mock<ILogger> mockLogger, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(extendedProperties, LogLevel.Error, times, failMessage);
+
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(extendedProperties, LogLevel.Fatal, times, failMessage);
+
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(extendedProperties, LogLevel.Audit, times, failMessage);
+
+        private static void VerifyLog(this Mock<ILogger> mockLogger, object extendedProperties,
+            LogLevel logLevel, Times? times, string failMessage)
+        {
+            if (mockLogger == null)
+                throw new ArgumentNullException(nameof(mockLogger));
+            if (extendedProperties == null)
+                throw new ArgumentNullException(nameof(extendedProperties));
+
+            var properties = GetExtendedPropertiesDictionary(extendedProperties);
+
+            Func<LogEntry, bool> hasMatchingExtendedProperties = logEntry =>
+            {
+                foreach (var property in properties)
+                {
+                    if (!logEntry.ExtendedProperties.TryGetValue(property.Key, out var value)
+                        || !value.GetType().IsAssignableFrom(property.Value.GetType()))
+                        return false;
+
+                    switch (property.Value)
+                    {
+                        case string pattern:
+                            if (!Regex.IsMatch((string)value, pattern))
+                                return false;
+                            break;
+                        default:
+                            if (!Equals(property.Value, value))
+                                return false;
+                            break;
+                    }
+                }
+                return true;
+            };
+
+            Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry =>
+                logEntry.Level == logLevel
+                && hasMatchingExtendedProperties(logEntry);
+
+            mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
+                times ?? Times.Once(), failMessage);
+        }
+
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Debug, times, failMessage);
+
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Info, times, failMessage);
+
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Warn, times, failMessage);
+
+        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Error, times, failMessage);
+
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Fatal, times, failMessage);
+
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            Times? times = null, string failMessage = null) =>
+            mockLogger.VerifyLog(messagePattern, extendedProperties, LogLevel.Audit, times, failMessage);
+
+        private static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+            LogLevel logLevel, Times? times, string failMessage)
+        {
+            if (mockLogger == null)
+                throw new ArgumentNullException(nameof(mockLogger));
+            if (messagePattern == null)
+                throw new ArgumentNullException(nameof(messagePattern));
+            if (extendedProperties == null)
+                throw new ArgumentNullException(nameof(extendedProperties));
+
+            var messageRegex = new Regex(messagePattern);
+
+            var properties = GetExtendedPropertiesDictionary(extendedProperties);
+
+            Func<LogEntry, bool> hasMatchingExtendedProperties = logEntry =>
+            {
+                foreach (var property in properties)
+                {
+                    if (!logEntry.ExtendedProperties.TryGetValue(property.Key, out var value)
+                        || !value.GetType().IsAssignableFrom(property.Value.GetType()))
+                        return false;
+
+                    switch (property.Value)
+                    {
+                        case string pattern:
+                            if (!Regex.IsMatch((string)value, pattern))
+                                return false;
+                            break;
+                        default:
+                            if (!Equals(property.Value, value))
+                                return false;
+                            break;
+                    }
+                }
+                return true;
+            };
+
+            Expression<Func<LogEntry, bool>> matchingLogEntry = logEntry =>
+                messageRegex.IsMatch(logEntry.Message)
+                && logEntry.Level == logLevel
+                && hasMatchingExtendedProperties(logEntry);
+
+            mockLogger.Verify(m => m.Log(It.Is(matchingLogEntry), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
+                times ?? Times.Once(), failMessage);
+        }
+
+        private static Dictionary<string, object> GetExtendedPropertiesDictionary(object extendedProperties)
+        {
+            var logEntry = new LogEntry();
+            logEntry.SetExtendedProperties(extendedProperties);
+            return logEntry.ExtendedProperties;
+        }
+    }
+}

--- a/RockLib.Logging.Moq/RockLib.Logging.Moq.csproj
+++ b/RockLib.Logging.Moq/RockLib.Logging.Moq.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>RockLib.Logging.Moq</PackageId>
+    <PackageVersion>1.0.0-alpha00</PackageVersion>
+    <Authors>Brian Friesen</Authors>
+    <Description>Extensions for verifying logging operations with Moq.</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/RockLib/RockLib.Logging</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <Copyright>Copyright 2020 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
+    <PackageTags>RockLib Logging Logger Extensions Moq</PackageTags>
+    <Version>1.0.0</Version>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Logging.AspNetCore.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="RockLib.Logging" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Adds extension methods for `Mock<ILogger>`:
  - `Setup`
    - Specifies setups on the mock logger for the `ILogger.Level` and `ILogger.Name` properties.
  - `VerifyDebug`
    - Verifies that the mock logger logged at `LogLevel.Debug`.
    - Overloads for ensuring the message matches a regular expression pattern or that it has specific extended properties.
  - `VerifyInfo`
    - Verifies that the mock logger logged at `LogLevel.Info`.
    - Overloads for ensuring the message matches a regular expression pattern or that it has specific extended properties.
  - `VerifyWarn`
    - Verifies that the mock logger logged at `LogLevel.Warn`.
    - Overloads for ensuring the message matches a regular expression pattern or that it has specific extended properties.
  - `VerifyError`
    - Verifies that the mock logger logged at `LogLevel.Error`.
    - Overloads for ensuring the message matches a regular expression pattern or that it has specific extended properties.
  - `VerifyFatal`
    - Verifies that the mock logger logged at `LogLevel.Fatal`.
    - Overloads for ensuring the message matches a regular expression pattern or that it has specific extended properties.
  - `VerifyAudit`
    - Verifies that the mock logger logged at `LogLevel.Audit`.
    - Overloads for ensuring the message matches a regular expression pattern or that it has specific extended properties.
  - `VerifyLog`
    - Verifies that the mock logger logged at any `LogLevel`.
    - Overloads for ensuring the message matches a regular expression pattern or that it has specific extended properties.
- Adds `MockLogger` class, inheriting from `Mock<ILogger>`.