### PR TITLE
Fix bug when using default logger

### DIFF
--- a/RockLib.Logging.Tests/DependencyInjection/LoggerBuilderExtensionsTests.cs
+++ b/RockLib.Logging.Tests/DependencyInjection/LoggerBuilderExtensionsTests.cs
@@ -232,17 +232,16 @@ namespace RockLib.Logging.Tests.DependencyInjection
 
             var formatter = new Mock<ILogFormatter>().Object;
 
-            builder.AddConsoleLogProvider(options =>
-            {
-                options.Level = LogLevel.Info;
-                options.SetFormatter(formatter);
-            });
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.Configure<ConsoleLogProviderOptions>(options => options.Level = LogLevel.Info);
+
+            builder.AddConsoleLogProvider(options => options.SetFormatter(formatter));
 
             var registration =
                 builder.LogProviderRegistrations.Should().ContainSingle()
                 .Subject;
 
-            var logProvider = registration.Invoke(_emptyServiceProvider);
+            var logProvider = registration.Invoke(serviceCollection.BuildServiceProvider());
 
             var consoleLogProvider =
                 logProvider.Should().BeOfType<ConsoleLogProvider>()
@@ -417,9 +416,11 @@ namespace RockLib.Logging.Tests.DependencyInjection
             var formatter = new Mock<ILogFormatter>().Object;
             var file = "c:\\foobar";
 
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.Configure<FileLogProviderOptions>(options => options.Level = LogLevel.Info);
+
             builder.AddFileLogProvider(options =>
             {
-                options.Level = LogLevel.Info;
                 options.File = file;
                 options.SetFormatter(formatter);
             });
@@ -428,7 +429,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
                 builder.LogProviderRegistrations.Should().ContainSingle()
                 .Subject;
 
-            var logProvider = registration.Invoke(_emptyServiceProvider);
+            var logProvider = registration.Invoke(serviceCollection.BuildServiceProvider());
 
             var fileLogProvider =
                 logProvider.Should().BeOfType<FileLogProvider>()
@@ -624,9 +625,11 @@ namespace RockLib.Logging.Tests.DependencyInjection
             var formatter = new Mock<ILogFormatter>().Object;
             var file = "c:\\foobar";
 
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.Configure<RollingFileLogProviderOptions>(options => options.Level = LogLevel.Info);
+
             builder.AddRollingFileLogProvider(options =>
             {
-                options.Level = LogLevel.Info;
                 options.File = file;
                 options.MaxFileSizeKilobytes = 123;
                 options.MaxArchiveCount = 456;
@@ -638,7 +641,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
                 builder.LogProviderRegistrations.Should().ContainSingle()
                 .Subject;
 
-            var logProvider = registration.Invoke(_emptyServiceProvider);
+            var logProvider = registration.Invoke(serviceCollection.BuildServiceProvider());
 
             var rollingFileLogProvider =
                 logProvider.Should().BeOfType<RollingFileLogProvider>()
@@ -666,7 +669,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
 
         private class TestLoggerBuilder : ILoggerBuilder
         {
-            public string LoggerName => "TestLogger";
+            public string LoggerName => Logger.DefaultName;
 
             public IList<Func<IServiceProvider, ILogProvider>> LogProviderRegistrations { get; } = new List<Func<IServiceProvider, ILogProvider>>();
 

--- a/RockLib.Logging.Tests/DependencyInjection/Options/FileLogProviderOptionsTests.cs
+++ b/RockLib.Logging.Tests/DependencyInjection/Options/FileLogProviderOptionsTests.cs
@@ -3,7 +3,7 @@ using RockLib.Logging.DependencyInjection;
 using System;
 using Xunit;
 
-namespace RockLib.Logging.Tests.DependencyInjection.Options
+namespace RockLib.Logging.Tests.DependencyInjection
 {
     public class FileLogProviderOptionsTests
     {

--- a/RockLib.Logging.Tests/DependencyInjection/Options/FormattableLogProviderOptionsTests.cs
+++ b/RockLib.Logging.Tests/DependencyInjection/Options/FormattableLogProviderOptionsTests.cs
@@ -5,7 +5,7 @@ using RockLib.Logging.DependencyInjection;
 using System;
 using Xunit;
 
-namespace RockLib.Logging.Tests.DependencyInjection.Options
+namespace RockLib.Logging.Tests.DependencyInjection
 {
     public class FormattableLogProviderOptionsTests
     {

--- a/RockLib.Logging.Tests/DependencyInjection/Options/RollingFileLogProviderOptionsTests.cs
+++ b/RockLib.Logging.Tests/DependencyInjection/Options/RollingFileLogProviderOptionsTests.cs
@@ -2,7 +2,7 @@
 using RockLib.Logging.DependencyInjection;
 using Xunit;
 
-namespace RockLib.Logging.Tests.DependencyInjection.Options
+namespace RockLib.Logging.Tests.DependencyInjection
 {
     public class RollingFileLogProviderOptionsTests
     {

--- a/RockLib.Logging/DependencyInjection/LoggerBuilderExtensions.cs
+++ b/RockLib.Logging/DependencyInjection/LoggerBuilderExtensions.cs
@@ -175,8 +175,12 @@ namespace RockLib.Logging.DependencyInjection
 
             return builder.AddLogProvider(serviceProvider =>
             {
+                var optionsLoggerName = builder.LoggerName == Logger.DefaultName
+                    ? Options.DefaultName
+                    : builder.LoggerName;
+
                 var optionsMonitor = serviceProvider.GetService<IOptionsMonitor<ConsoleLogProviderOptions>>();
-                var options = optionsMonitor?.Get(builder.LoggerName) ?? new ConsoleLogProviderOptions();
+                var options = optionsMonitor?.Get(optionsLoggerName) ?? new ConsoleLogProviderOptions();
                 configureOptions?.Invoke(options);
 
                 var formatter = options.FormatterRegistration?.Invoke(serviceProvider)
@@ -313,8 +317,12 @@ namespace RockLib.Logging.DependencyInjection
 
             return builder.AddLogProvider(serviceProvider =>
             {
+                var optionsLoggerName = builder.LoggerName == Logger.DefaultName
+                    ? Options.DefaultName
+                    : builder.LoggerName;
+
                 var optionsMonitor = serviceProvider.GetService<IOptionsMonitor<FileLogProviderOptions>>();
-                var options = optionsMonitor?.Get(builder.LoggerName) ?? new FileLogProviderOptions();
+                var options = optionsMonitor?.Get(optionsLoggerName) ?? new FileLogProviderOptions();
                 configureOptions?.Invoke(options);
 
                 var formatter = options.FormatterRegistration?.Invoke(serviceProvider)
@@ -519,8 +527,12 @@ namespace RockLib.Logging.DependencyInjection
 
             return builder.AddLogProvider(serviceProvider =>
             {
+                var optionsLoggerName = builder.LoggerName == Logger.DefaultName
+                    ? Options.DefaultName
+                    : builder.LoggerName;
+
                 var optionsMonitor = serviceProvider.GetService<IOptionsMonitor<RollingFileLogProviderOptions>>();
-                var options = optionsMonitor?.Get(builder.LoggerName) ?? new RollingFileLogProviderOptions();
+                var options = optionsMonitor?.Get(optionsLoggerName) ?? new RollingFileLogProviderOptions();
                 configureOptions?.Invoke(options);
 
                 var formatter = options.FormatterRegistration?.Invoke(serviceProvider)


### PR DESCRIPTION
The bug can be reproduced with the following example:

```c#
void Configure(IServiceCollection services)
{
    serviceCollection.Configure<ConsoleLogProviderOptions>(options => options.Level = LogLevel.Info);

    serviceCollection.AddLogger()
        .AddConsoleLogProvider();
}
```

The bug happens because our default logger name, "default", is different than Microsoft's default options name - "" (empty string).