### PR TITLE
Log method does nothing when LogProcessor is disposed

### DIFF
--- a/RockLib.Logging.Tests/LoggerTests.cs
+++ b/RockLib.Logging.Tests/LoggerTests.cs
@@ -85,14 +85,15 @@ namespace RockLib.Logging.Tests
         }
 
         [Fact]
-        public void LogThrowsObjectDisposedExceptionAfterLogProcessorHasBeenDisposed()
+        public void LogDoesNotCallLogProcessorWhenItHasBeenDisposed()
         {
             var mockLogProcessor = new Mock<ILogProcessor>();
             mockLogProcessor.Setup(m => m.IsDisposed).Returns(true);
 
             var logger = new Logger(mockLogProcessor.Object);
 
-            Assert.Throws<ObjectDisposedException>(() => logger.Log(new LogEntry("Hello, world!", LogLevel.Info)));
+            mockLogProcessor.Verify(m => m.ProcessLogEntry(It.IsAny<ILogger>(), It.IsAny<LogEntry>()),
+                Times.Never);
         }
 
         [Fact]

--- a/RockLib.Logging/LogProcessing/BackgroundLogProcessor.cs
+++ b/RockLib.Logging/LogProcessing/BackgroundLogProcessor.cs
@@ -126,9 +126,6 @@ namespace RockLib.Logging.LogProcessing
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            if (IsDisposed)
-                return;
-
             lock (_disposeLocker)
             {
                 if (IsDisposed)

--- a/RockLib.Logging/Logger.cs
+++ b/RockLib.Logging/Logger.cs
@@ -162,9 +162,8 @@ namespace RockLib.Logging
             [CallerLineNumber] int callerLineNumber = 0)
         {
             if (logEntry == null) throw new ArgumentNullException(nameof(logEntry));
-            if (LogProcessor.IsDisposed) throw new ObjectDisposedException("Cannot log to a Logger with a disposed LogProcessor.");
 
-            if (!_canProcessLogs || logEntry.Level < Level)
+            if (LogProcessor.IsDisposed || !_canProcessLogs || logEntry.Level < Level)
                 return;
 
             logEntry.CallerInfo = $"{callerFilePath}:{callerMemberName}({callerLineNumber})";


### PR DESCRIPTION
...instead of throwing an ObjectDisposedException.