### PR TITLE
Don't register for domain events in BackgroundLogProcessor constructor

### DIFF
--- a/RockLib.Logging/LogProcessing/BackgroundLogProcessor.cs
+++ b/RockLib.Logging/LogProcessing/BackgroundLogProcessor.cs
@@ -30,9 +30,6 @@ namespace RockLib.Logging.LogProcessing
             _processingThread.Start();
             _trackingThread = new Thread(TrackWriteTasks) { IsBackground = true };
             _trackingThread.Start();
-
-            AppDomain.CurrentDomain.ProcessExit += (sender, eventArgs) => Dispose(true);
-            AppDomain.CurrentDomain.DomainUnload += (sender, eventArgs) => Dispose(true);
         }
 
         /// <summary>


### PR DESCRIPTION
The only BackgroundLogProcessor that we need to "try really, really hard to dispose" is the one used by the ProcessingMode constructor, so don't register domain events for every instance. Instead, use same instance of BackgroundLogProcessor for each Logger with ProcessingMode.Background, and only register domain events to dispose this singleton.