### PR TITLE
Define DEBUG symbol in DebugLogProvider

### DIFF
--- a/RockLib.Logging/LogProviders/DebugLogProvider.cs
+++ b/RockLib.Logging/LogProviders/DebugLogProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#define DEBUG
+using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
...otherwise, the compiler removes the call to Debug.WriteLine.