### PR TITLE
Fix memory leak when using LoggerLookup

### DIFF
--- a/RockLib.Logging/CHANGELOG.md
+++ b/RockLib.Logging/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Fixed
+
+- Fixes memory leak when using `LoggerLookup`.
+
 ## 3.0.3
+
+#### Added
 
 - Adds RockLib.Logging.Analyzers package reference.
 

--- a/RockLib.Logging/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/RockLib.Logging/DependencyInjection/ServiceCollectionExtensions.cs
@@ -49,7 +49,7 @@ namespace RockLib.Logging.DependencyInjection
 
             services.SetLogProcessor(logProcessor);
             services.Add(new ServiceDescriptor(typeof(ILogger), builder.Build, lifetime));
-            services.SetLoggerLookupDescriptor();
+            services.SetLoggerLookupDescriptor(lifetime);
 
             return builder;
         }
@@ -93,7 +93,7 @@ namespace RockLib.Logging.DependencyInjection
 
             services.SetLogProcessor(logProcessorRegistration);
             services.Add(new ServiceDescriptor(typeof(ILogger), builder.Build, lifetime));
-            services.SetLoggerLookupDescriptor();
+            services.SetLoggerLookupDescriptor(lifetime);
 
             return builder;
         }
@@ -132,7 +132,7 @@ namespace RockLib.Logging.DependencyInjection
 
             services.SetLogProcessor(processingMode);
             services.Add(new ServiceDescriptor(typeof(ILogger), builder.Build, lifetime));
-            services.SetLoggerLookupDescriptor();
+            services.SetLoggerLookupDescriptor(lifetime);
 
             return builder;
         }
@@ -175,7 +175,7 @@ namespace RockLib.Logging.DependencyInjection
                     services.RemoveAt(i--);
         }
 
-        private static void SetLoggerLookupDescriptor(this IServiceCollection services)
+        private static void SetLoggerLookupDescriptor(this IServiceCollection services, ServiceLifetime lifetime)
         {
             // Clear the existing LoggerLookup descriptor, if it exists.
             for (int i = 0; i < services.Count; i++)
@@ -201,7 +201,7 @@ namespace RockLib.Logging.DependencyInjection
                 return selectedLogger;
             };
 
-            services.AddSingleton(LoggerLookupRegistration);
+            services.Add(new ServiceDescriptor(typeof(LoggerLookup), LoggerLookupRegistration, lifetime));
         }
 
         internal static bool NamesEqual(string loggerName, string lookupName)

--- a/Tests/RockLib.Logging.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/Tests/RockLib.Logging.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
             services[1].ImplementationFactory.Target.Should().BeSameAs(builder);
 
             services[2].ServiceType.Should().Be<LoggerLookup>();
-            services[2].Lifetime.Should().Be(ServiceLifetime.Singleton);
+            services[2].Lifetime.Should().Be(ServiceLifetime.Scoped);
             services[2].ImplementationFactory.Should().NotBeNull();
         }
 
@@ -81,7 +81,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
             services[1].ImplementationFactory.Target.Should().BeSameAs(builder);
 
             services[2].ServiceType.Should().Be<LoggerLookup>();
-            services[2].Lifetime.Should().Be(ServiceLifetime.Singleton);
+            services[2].Lifetime.Should().Be(ServiceLifetime.Scoped);
             services[2].ImplementationFactory.Should().NotBeNull();
         }
 
@@ -128,7 +128,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
             services[1].ImplementationFactory.Target.Should().BeSameAs(builder);
 
             services[2].ServiceType.Should().Be<LoggerLookup>();
-            services[2].Lifetime.Should().Be(ServiceLifetime.Singleton);
+            services[2].Lifetime.Should().Be(ServiceLifetime.Scoped);
             services[2].ImplementationFactory.Should().NotBeNull();
         }
 
@@ -152,7 +152,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
             services[1].ImplementationFactory.Target.Should().BeSameAs(builder);
 
             services[2].ServiceType.Should().Be<LoggerLookup>();
-            services[2].Lifetime.Should().Be(ServiceLifetime.Singleton);
+            services[2].Lifetime.Should().Be(ServiceLifetime.Scoped);
             services[2].ImplementationFactory.Should().NotBeNull();
         }
 
@@ -176,7 +176,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
             services[1].ImplementationFactory.Target.Should().BeSameAs(builder);
 
             services[2].ServiceType.Should().Be<LoggerLookup>();
-            services[2].Lifetime.Should().Be(ServiceLifetime.Singleton);
+            services[2].Lifetime.Should().Be(ServiceLifetime.Scoped);
             services[2].ImplementationFactory.Should().NotBeNull();
         }
 


### PR DESCRIPTION
When registering `LoggerLookup`, use the same lifetime as `ILogger` (instead of always singleton).