### PR TITLE
Add ability to add [SafeToLog] and [NotSafeToLog] at runtime

### DIFF
--- a/RockLib.Logging/SafeLogging/NotSafeToLogAttribute.cs
+++ b/RockLib.Logging/SafeLogging/NotSafeToLogAttribute.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
 
 namespace RockLib.Logging.SafeLogging
 {
@@ -9,5 +11,38 @@ namespace RockLib.Logging.SafeLogging
     [AttributeUsage(AttributeTargets.Property)]
     public class NotSafeToLogAttribute : Attribute
     {
+        /// <summary>
+        /// Decorate the specified property with the <see cref="NotSafeToLogAttribute"/>.
+        /// </summary>
+        /// <param name="property">The property to decorate.</param>
+        public static void Decorate(PropertyInfo property)
+        {
+            if (property is null)
+                throw new ArgumentNullException(nameof(property));
+
+            SanitizeEngine.NotSafeProperties.Add(property);
+        }
+
+        /// <summary>
+        /// Decorate the property specified by the expression with the <see cref="NotSafeToLogAttribute"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the property to decorate.</typeparam>
+        /// <param name="expression">An expression that defines the property to decorate.</param>
+        public static void Decorate<T>(Expression<Func<T, object>> expression)
+        {
+            if (expression is null)
+                throw new ArgumentNullException(nameof(expression));
+
+            if (expression.Body is MemberExpression memberExpression
+                && memberExpression.Expression == expression.Parameters[0]
+                && memberExpression.Member is PropertyInfo property)
+            {
+                Decorate(property);
+            }
+            else
+            {
+                throw new ArgumentException($"Expression does not define a property of type {typeof(T).Name}.", nameof(expression));
+            }
+        }
     }
 }

--- a/RockLib.Logging/SafeLogging/SanitizeEngine.cs
+++ b/RockLib.Logging/SafeLogging/SanitizeEngine.cs
@@ -14,6 +14,8 @@ namespace RockLib.Logging.SafeLogging
     /// </summary>
     public static class SanitizeEngine
     {
+        private static readonly Type _runtimeTypeType = typeof(SanitizeEngine).GetType();
+
         private static readonly ConcurrentDictionary<Type, Func<object, object>> _sanitizeFunctions = new ConcurrentDictionary<Type, Func<object, object>>();
 
         /// <summary>
@@ -78,8 +80,8 @@ namespace RockLib.Logging.SafeLogging
             || runtimeType == typeof(DateTimeOffset)
             || runtimeType == typeof(Guid)
             || runtimeType == typeof(Uri)
-            || runtimeType == typeof(Encoding)
-            || runtimeType == typeof(Type);
+            | typeof(Encoding).IsAssignableFrom(runtimeType)
+            || runtimeType == _runtimeTypeType;
 
         private static bool IsCollection(Type runtimeType) =>
             typeof(IEnumerable).IsAssignableFrom(runtimeType);

--- a/RockLib.Logging/SafeLogging/SanitizeEngine.cs
+++ b/RockLib.Logging/SafeLogging/SanitizeEngine.cs
@@ -18,6 +18,10 @@ namespace RockLib.Logging.SafeLogging
 
         private static readonly ConcurrentDictionary<Type, Func<object, object>> _sanitizeFunctions = new ConcurrentDictionary<Type, Func<object, object>>();
 
+        internal static readonly HashSet<Type> SafeTypes = new HashSet<Type>();
+        internal static readonly HashSet<PropertyInfo> SafeProperties = new HashSet<PropertyInfo>();
+        internal static readonly HashSet<PropertyInfo> NotSafeProperties = new HashSet<PropertyInfo>();
+
         /// <summary>
         /// Ensures that any properties not decorated with the [SafeToLog] attribute are excluded
         /// from logs. Note that non-complex types (e.g. primitive types, enums, string) are not
@@ -192,12 +196,15 @@ namespace RockLib.Logging.SafeLogging
 
         private static IEnumerable<PropertyInfo> GetSafeProperties(Type type, IReadOnlyCollection<PropertyInfo> allProperties)
         {
-            if (Attribute.IsDefined(type, typeof(SafeToLogAttribute), inherit: false))
+            if (Attribute.IsDefined(type, typeof(SafeToLogAttribute), inherit: false)
+                    || SafeTypes.Contains(type))
                 return allProperties.Where(property =>
-                    !Attribute.IsDefined(property, typeof(NotSafeToLogAttribute), inherit: false));
+                    !Attribute.IsDefined(property, typeof(NotSafeToLogAttribute), inherit: false)
+                        && !NotSafeProperties.Contains(property));
 
             return allProperties.Where(property =>
-                Attribute.IsDefined(property, typeof(SafeToLogAttribute), inherit: false));
+                Attribute.IsDefined(property, typeof(SafeToLogAttribute), inherit: false)
+                    || SafeProperties.Contains(property));
         }
     }
 }

--- a/Tests/RockLib.Logging.Tests/SafeLogging/SanitizeEngineTests.cs
+++ b/Tests/RockLib.Logging.Tests/SafeLogging/SanitizeEngineTests.cs
@@ -1,0 +1,233 @@
+﻿using FluentAssertions;
+using RockLib.Logging.SafeLogging;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace RockLib.Logging.Tests.SafeLogging
+{
+    public class SanitizeEngineTests
+    {
+        [Fact(DisplayName = "Sanitize method transforms safe-to-log type into string dictionary")]
+        public void SanitizeMethodTest1()
+        {
+            var value = new ExampleSafeToLogType { Foo = "abc", Bar = "xyz" };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            sanitizedValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method transforms type with safe-to-log properties into string dictionary")]
+        public void SanitizeMethodTest2()
+        {
+            var value = new ExampleSafeToLogProperty { Foo = "abc", Bar = "xyz" };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            sanitizedValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Bar", "xyz" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method transforms not-safe-to-log object into \"everything sanitized\" message")]
+        public void SanitizeMethodTest3()
+        {
+            var value = new ExampleNotSafeToLog1 { Foo = "abc", Bar = "xyz" };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            sanitizedValue.Should().BeOfType<string>()
+                .Which.Should().Be($"All properties from the {typeof(ExampleNotSafeToLog1).FullName} type have been excluded from the log entry extended properties because none were decorated with the [SafeToLog] attribute.");
+        }
+
+        [Fact(DisplayName = "Sanitize method sanitizes the values of a string dictionary")]
+        public void SanitizeMethodTest4()
+        {
+            var value = new Dictionary<string, object>
+            {
+                {"Garply", new ExampleSafeToLogType { Foo = "abc", Bar = "xyz" } },
+                {"Grault", new ExampleSafeToLogProperty { Foo = "abc", Bar = "xyz" } }
+            };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            var sanitizedDictionary =
+                sanitizedValue.Should().BeOfType<Dictionary<string, object>>()
+                    .Subject;
+
+            sanitizedDictionary.Should().ContainKey("Garply")
+                .WhichValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
+
+            sanitizedDictionary.Should().ContainKey("Grault")
+                .WhichValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Bar", "xyz" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method sanitizes the values of a non-string generic dictionary")]
+        public void SanitizeMethodTest5()
+        {
+            var value = new Dictionary<string, object>
+            {
+                {"Garply", new ExampleSafeToLogType { Foo = "abc", Bar = "xyz" } },
+                {"Grault", new ExampleSafeToLogProperty { Foo = "abc", Bar = "xyz" } }
+            };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            var sanitizedDictionary =
+                sanitizedValue.Should().BeOfType<Dictionary<string, object>>()
+                    .Subject;
+
+            sanitizedDictionary.Should().ContainKey("Garply")
+                .WhichValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
+
+            sanitizedDictionary.Should().ContainKey("Grault")
+                .WhichValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Bar", "xyz" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method sanitizes the values of a non-generic dictionary")]
+        public void SanitizeMethodTest6()
+        {
+            var value = new Hashtable
+            {
+                {"Garply", new ExampleSafeToLogType { Foo = "abc", Bar = "xyz" } },
+                {"Grault", new ExampleSafeToLogProperty { Foo = "abc", Bar = "xyz" } }
+            };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            var sanitizedCollection =
+                sanitizedValue.Should().BeOfType<ArrayList>()
+                    .Subject;
+
+            sanitizedCollection.Should().HaveCount(2);
+            var garply = sanitizedCollection.Cast<DictionaryEntry>().First(x => x.Key is string key && key == "Garply");
+            var grault = sanitizedCollection.Cast<DictionaryEntry>().First(x => x.Key is string key && key == "Grault");
+
+            garply.Value.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
+            grault.Value.Should().BeEquivalentTo(new Dictionary<string, object> { { "Bar", "xyz" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method sanitizes the values of a collection")]
+        public void SanitizeMethodTest7()
+        {
+            var value = new List<object>
+            {
+                new ExampleSafeToLogType { Foo = "abc", Bar = "xyz" },
+                new ExampleSafeToLogProperty { Foo = "abc", Bar = "xyz" }
+            };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            var sanitizedCollection =
+                sanitizedValue.Should().BeOfType<ArrayList>()
+                    .Subject;
+
+            sanitizedCollection.Should().HaveCount(2);
+            
+            sanitizedCollection[0].Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
+
+            sanitizedCollection[1].Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Bar", "xyz" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method does not change types whitelisted by IsTypeSafeToLog")]
+        public void SanitizeMethodTest8()
+        {
+            SanitizeEngine.IsTypeSafeToLog = type => type == typeof(ExampleNotSafeToLog4);
+
+            try
+            {
+                var value = new ExampleNotSafeToLog4 { Foo = "abc", Bar = "xyz" };
+
+                var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+                sanitizedValue.Should().BeSameAs(value);
+            }
+            finally
+            {
+                SanitizeEngine.IsTypeSafeToLog = null;
+            }
+        }
+
+        [Theory(DisplayName = "Sanitize method does not change \"value\" types")]
+        [MemberData(nameof(SanitizeMethodTest1TestData))]
+        public void SanitizeMethodTest9(object value)
+        {
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            sanitizedValue.Should().Be(value);
+        }
+
+        public static IEnumerable<object[]> SanitizeMethodTest1TestData
+        {
+            get
+            {
+                yield return new object[] { 123 };
+                yield return new object[] { Base64FormattingOptions.InsertLineBreaks };
+                yield return new object[] { "Hello, world!" };
+                yield return new object[] { 123.45M };
+                yield return new object[] { DateTime.Now };
+                yield return new object[] { DateTime.Now.TimeOfDay };
+                yield return new object[] { DateTimeOffset.Now };
+                yield return new object[] { Guid.NewGuid() };
+                yield return new object[] { new Uri("https://google.com") };
+                yield return new object[] { Encoding.UTF8 };
+                yield return new object[] { typeof(SanitizeEngineTests) };
+            }
+        }
+
+        public class ExampleNotSafeToLog1
+        {
+            public string Foo { get; set; }
+
+            public string Bar { get; set; }
+        }
+
+        public class ExampleNotSafeToLog2
+        {
+            public string Foo { get; set; }
+
+            public string Bar { get; set; }
+        }
+
+        public class ExampleNotSafeToLog3
+        {
+            public string Foo { get; set; }
+
+            public string Bar { get; set; }
+        }
+
+        public class ExampleNotSafeToLog4
+        {
+            public string Foo { get; set; }
+
+            public string Bar { get; set; }
+        }
+
+        [SafeToLog]
+        public class ExampleSafeToLogType
+        {
+            public string Foo { get; set; }
+
+            [NotSafeToLog]
+            public string Bar { get; set; }
+        }
+
+        public class ExampleSafeToLogProperty
+        {
+            public string Foo { get; set; }
+
+            [SafeToLog]
+            public string Bar { get; set; }
+        }
+    }
+}

--- a/Tests/RockLib.Logging.Tests/SafeLogging/SanitizeEngineTests.cs
+++ b/Tests/RockLib.Logging.Tests/SafeLogging/SanitizeEngineTests.cs
@@ -11,7 +11,7 @@ namespace RockLib.Logging.Tests.SafeLogging
 {
     public class SanitizeEngineTests
     {
-        [Fact(DisplayName = "Sanitize method transforms safe-to-log type into string dictionary")]
+        [Fact(DisplayName = "Sanitize method transforms safe-to-log type (defined at compile-time) into string dictionary")]
         public void SanitizeMethodTest1()
         {
             var value = new ExampleSafeToLogType { Foo = "abc", Bar = "xyz" };
@@ -22,7 +22,7 @@ namespace RockLib.Logging.Tests.SafeLogging
                 .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
         }
 
-        [Fact(DisplayName = "Sanitize method transforms type with safe-to-log properties into string dictionary")]
+        [Fact(DisplayName = "Sanitize method transforms type with safe-to-log properties (defined at compile-time) into string dictionary")]
         public void SanitizeMethodTest2()
         {
             var value = new ExampleSafeToLogProperty { Foo = "abc", Bar = "xyz" };
@@ -44,8 +44,35 @@ namespace RockLib.Logging.Tests.SafeLogging
                 .Which.Should().Be($"All properties from the {typeof(ExampleNotSafeToLog1).FullName} type have been excluded from the log entry extended properties because none were decorated with the [SafeToLog] attribute.");
         }
 
-        [Fact(DisplayName = "Sanitize method sanitizes the values of a string dictionary")]
+        [Fact(DisplayName = "Sanitize method transforms safe-to-log type (defined at run-time) into string dictionary")]
         public void SanitizeMethodTest4()
+        {
+            SafeToLogAttribute.Decorate<ExampleNotSafeToLog2>();
+            NotSafeToLogAttribute.Decorate<ExampleNotSafeToLog2>(x => x.Bar);
+
+            var value = new ExampleNotSafeToLog2 { Foo = "abc", Bar = "xyz" };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            sanitizedValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method transforms type with safe-to-log properties (defined at run-time) into string dictionary")]
+        public void SanitizeMethodTest5()
+        {
+            SafeToLogAttribute.Decorate<ExampleNotSafeToLog3>(x => x.Foo);
+
+            var value = new ExampleNotSafeToLog3 { Foo = "abc", Bar = "xyz" };
+
+            var sanitizedValue = SanitizeEngine.Sanitize(value);
+
+            sanitizedValue.Should().BeOfType<Dictionary<string, object>>()
+                .Which.Should().BeEquivalentTo(new Dictionary<string, object> { { "Foo", "abc" } });
+        }
+
+        [Fact(DisplayName = "Sanitize method sanitizes the values of a string dictionary")]
+        public void SanitizeMethodTest6()
         {
             var value = new Dictionary<string, object>
             {
@@ -69,7 +96,7 @@ namespace RockLib.Logging.Tests.SafeLogging
         }
 
         [Fact(DisplayName = "Sanitize method sanitizes the values of a non-string generic dictionary")]
-        public void SanitizeMethodTest5()
+        public void SanitizeMethodTest7()
         {
             var value = new Dictionary<string, object>
             {
@@ -93,7 +120,7 @@ namespace RockLib.Logging.Tests.SafeLogging
         }
 
         [Fact(DisplayName = "Sanitize method sanitizes the values of a non-generic dictionary")]
-        public void SanitizeMethodTest6()
+        public void SanitizeMethodTest8()
         {
             var value = new Hashtable
             {
@@ -116,7 +143,7 @@ namespace RockLib.Logging.Tests.SafeLogging
         }
 
         [Fact(DisplayName = "Sanitize method sanitizes the values of a collection")]
-        public void SanitizeMethodTest7()
+        public void SanitizeMethodTest9()
         {
             var value = new List<object>
             {
@@ -140,7 +167,7 @@ namespace RockLib.Logging.Tests.SafeLogging
         }
 
         [Fact(DisplayName = "Sanitize method does not change types whitelisted by IsTypeSafeToLog")]
-        public void SanitizeMethodTest8()
+        public void SanitizeMethodTest10()
         {
             SanitizeEngine.IsTypeSafeToLog = type => type == typeof(ExampleNotSafeToLog4);
 
@@ -160,7 +187,7 @@ namespace RockLib.Logging.Tests.SafeLogging
 
         [Theory(DisplayName = "Sanitize method does not change \"value\" types")]
         [MemberData(nameof(SanitizeMethodTest1TestData))]
-        public void SanitizeMethodTest9(object value)
+        public void SanitizeMethodTest11(object value)
         {
             var sanitizedValue = SanitizeEngine.Sanitize(value);
 


### PR DESCRIPTION
This allows apps to types that are not owned by the app to be sanitized.