### PR TITLE
remove analyzer package, bump to v3.0.7

### DIFF
--- a/RockLib.Logging/CHANGELOG.md
+++ b/RockLib.Logging/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.7 - 2021-07-30
+
+#### Removed
+
+- Removed RockLib.Logging.Analyzers since Microsoft.Analysis.CSharp v3.9 is not compatible with .net3.1.
+
 ## 3.0.6 - 2021-07-22
 
 #### Changed

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>3.0.6</PackageVersion>
+    <PackageVersion>3.0.7</PackageVersion>
     <Authors>RockLib</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -43,7 +43,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RockLib.Diagnostics" Version="1.0.8" />
-    <PackageReference Include="RockLib.Logging.Analyzers" Version="1.0.2" />
     <PackageReference Include="RockLib.Reflection.Optimized" Version="1.3.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
@@ -55,7 +54,7 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net462' Or '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Analyzers were using some c# 9.0 features which require .net5. Removing analyzer packages.