### PR TITLE
Rename message parameter and improve docs

### DIFF
--- a/RockLib.Logging.Moq/CHANGELOG.md
+++ b/RockLib.Logging.Moq/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Fixed
+
+- Fixes parameter name and doc comments in VerifyLog extension methods.
+
 ## 1.2.5 - 2021-08-11
 
 #### Changed
@@ -31,7 +37,8 @@ RockLib.Logging.Moq. What follows below are the original release notes.
 
 ## 1.2.2 - 2021-02-25
 
-Improves the error message when logging verification fails.
+- Improves the error message when logging verification fails.
+- Use string equality comparison by default. Match as regex only if the value starts and ends with '/'. For example "/(?i)hello,\s+world[.!?]/".
 
 ## 1.2.1 - 2021-02-19
 

--- a/RockLib.Logging.Moq/MockLoggerExtensions.VerifyLog.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.VerifyLog.cs
@@ -10,7 +10,7 @@ namespace RockLib.Logging.Moq
 {
     partial class MockLoggerExtensions
     {
-        private static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern,
+        private static void VerifyLog(this Mock<ILogger> mockLogger, string message,
             Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             LogLevel? logLevel, Times? times, string failMessage)
         {
@@ -19,8 +19,8 @@ namespace RockLib.Logging.Moq
 
             Expression<Func<LogEntry, bool>> matchingMessage = null, matchingExtendedProperties = null, matchingLogLevel = null;
 
-            if (messagePattern != null)
-                matchingMessage = GetMatchingMessageExpression(messagePattern);
+            if (message != null)
+                matchingMessage = GetMatchingMessageExpression(message);
 
             if (extendedProperties != null)
                 matchingExtendedProperties = GetMatchingExtendedPropertiesExpression(extendedProperties);
@@ -34,20 +34,20 @@ namespace RockLib.Logging.Moq
                 times ?? Times.Once(), failMessage);
         }
 
-        private static Expression<Func<LogEntry, bool>> GetMatchingMessageExpression(string messagePattern)
+        private static Expression<Func<LogEntry, bool>> GetMatchingMessageExpression(string message)
         {
             var logEntryParameter = Expression.Parameter(typeof(LogEntry), "logEntry");
             Expression body;
 
-            if (messagePattern.StartsWith("/") && messagePattern.EndsWith("/"))
+            if (message.StartsWith("/") && message.EndsWith("/"))
             {
                 var isMatchMethod = typeof(Regex).GetMethod(nameof(Regex.IsMatch), new Type[] { typeof(string), typeof(string) });
                 body = Expression.Call(isMatchMethod,
                     Expression.Property(logEntryParameter, nameof(LogEntry.Message)),
-                    Expression.Constant(messagePattern.Substring(1, messagePattern.Length - 2)));
+                    Expression.Constant(message.Substring(1, message.Length - 2)));
             }            
             else
-                body = Expression.Equal(Expression.Property(logEntryParameter, nameof(LogEntry.Message)), Expression.Constant(messagePattern));
+                body = Expression.Equal(Expression.Property(logEntryParameter, nameof(LogEntry.Message)), Expression.Constant(message));
 
             return Expression.Lambda<Func<LogEntry, bool>>(body, logEntryParameter);
         }

--- a/RockLib.Logging.Moq/MockLoggerExtensions.cs
+++ b/RockLib.Logging.Moq/MockLoggerExtensions.cs
@@ -144,13 +144,15 @@ namespace RockLib.Logging.Moq
             mockLogger.VerifyLog(null, null, null, null, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// at <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -160,18 +162,20 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern,
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string message,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, null, LogLevel.Debug, times, failMessage);
+            mockLogger.VerifyLog(message, null, null, LogLevel.Debug, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// at <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -181,18 +185,20 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern,
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string message,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, null, LogLevel.Info, times, failMessage);
+            mockLogger.VerifyLog(message, null, null, LogLevel.Info, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// at <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -202,18 +208,20 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern,
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string message,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, null, LogLevel.Warn, times, failMessage);
+            mockLogger.VerifyLog(message, null, null, LogLevel.Warn, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// at <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -223,18 +231,20 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern,
+        public static void VerifyError(this Mock<ILogger> mockLogger, string message,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, null, LogLevel.Error, times, failMessage);
+            mockLogger.VerifyLog(message, null, null, LogLevel.Error, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// at <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -244,18 +254,20 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern,
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string message,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, null, LogLevel.Fatal, times, failMessage);
+            mockLogger.VerifyLog(message, null, null, LogLevel.Fatal, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// at <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -265,18 +277,20 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern,
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string message,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, null, LogLevel.Audit, times, failMessage);
+            mockLogger.VerifyLog(message, null, null, LogLevel.Audit, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// at any <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -286,9 +300,9 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern,
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string message,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, null, null, times, failMessage);
+            mockLogger.VerifyLog(message, null, null, null, times, failMessage);
 
         /// <summary>
         /// Verifies that the mock logger logged with the extended properties specified by
@@ -445,14 +459,16 @@ namespace RockLib.Logging.Moq
             mockLogger.VerifyLog(null, null, extendedProperties, null, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="extendedProperties">
         /// An object representing the extended properties that a log must match in order for successful
@@ -466,19 +482,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string message, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, extendedProperties, LogLevel.Debug, times, failMessage);
+            mockLogger.VerifyLog(message, null, extendedProperties, LogLevel.Debug, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="extendedProperties">
         /// An object representing the extended properties that a log must match in order for successful
@@ -492,19 +510,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string message, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, extendedProperties, LogLevel.Info, times, failMessage);
+            mockLogger.VerifyLog(message, null, extendedProperties, LogLevel.Info, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="extendedProperties">
         /// An object representing the extended properties that a log must match in order for successful
@@ -518,19 +538,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string message, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, extendedProperties, LogLevel.Warn, times, failMessage);
+            mockLogger.VerifyLog(message, null, extendedProperties, LogLevel.Warn, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="extendedProperties">
         /// An object representing the extended properties that a log must match in order for successful
@@ -544,19 +566,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+        public static void VerifyError(this Mock<ILogger> mockLogger, string message, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, extendedProperties, LogLevel.Error, times, failMessage);
+            mockLogger.VerifyLog(message, null, extendedProperties, LogLevel.Error, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="extendedProperties">
         /// An object representing the extended properties that a log must match in order for successful
@@ -570,19 +594,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string message, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, extendedProperties, LogLevel.Fatal, times, failMessage);
+            mockLogger.VerifyLog(message, null, extendedProperties, LogLevel.Fatal, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="extendedProperties">
         /// An object representing the extended properties that a log must match in order for successful
@@ -596,19 +622,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string message, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, extendedProperties, LogLevel.Audit, times, failMessage);
+            mockLogger.VerifyLog(message, null, extendedProperties, LogLevel.Audit, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the extended properties specified by <paramref name="extendedProperties"/> at any
         /// <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="extendedProperties">
         /// An object representing the extended properties that a log must match in order for successful
@@ -622,9 +650,9 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, object extendedProperties,
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string message, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, null, extendedProperties, null, times, failMessage);
+            mockLogger.VerifyLog(message, null, extendedProperties, null, times, failMessage);
 
         /// <summary>
         /// Verifies that the mock logger logged with the exception specified by <paramref name="exception"/>
@@ -774,14 +802,16 @@ namespace RockLib.Logging.Moq
             mockLogger.VerifyLog(null, ex => ReferenceEquals(ex, exception), null, null, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the exception specified by <paramref name="exception"/> at <see cref="LogLevel.Debug"/> the
         /// number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -796,12 +826,12 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern, Exception exception,
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string message, Exception exception,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), null, LogLevel.Debug, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), null, LogLevel.Debug, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the exception specified by <paramref name="exception"/> at <see cref="LogLevel.Info"/> the
         /// number of times specified by <paramref name="times"/>.
         /// </summary>
@@ -811,9 +841,11 @@ namespace RockLib.Logging.Moq
         /// reference to in order for successful verification to occur. Pass <see langword="null"/>
         /// if <see cref="LogEntry.Exception"/> is expected to be <see langword="null"/>.
         /// </param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -823,12 +855,12 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern, Exception exception,
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string message, Exception exception,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), null, LogLevel.Info, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), null, LogLevel.Info, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the exception specified by <paramref name="exception"/> at <see cref="LogLevel.Warn"/> the
         /// number of times specified by <paramref name="times"/>.
         /// </summary>
@@ -838,9 +870,11 @@ namespace RockLib.Logging.Moq
         /// reference to in order for successful verification to occur. Pass <see langword="null"/>
         /// if <see cref="LogEntry.Exception"/> is expected to be <see langword="null"/>.
         /// </param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -850,12 +884,12 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern, Exception exception,
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string message, Exception exception,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), null, LogLevel.Warn, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), null, LogLevel.Warn, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the exception specified by <paramref name="exception"/> at <see cref="LogLevel.Error"/> the
         /// number of times specified by <paramref name="times"/>.
         /// </summary>
@@ -865,9 +899,11 @@ namespace RockLib.Logging.Moq
         /// reference to in order for successful verification to occur. Pass <see langword="null"/>
         /// if <see cref="LogEntry.Exception"/> is expected to be <see langword="null"/>.
         /// </param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -877,12 +913,12 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern, Exception exception,
+        public static void VerifyError(this Mock<ILogger> mockLogger, string message, Exception exception,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), null, LogLevel.Error, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), null, LogLevel.Error, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the exception specified by <paramref name="exception"/> at <see cref="LogLevel.Fatal"/> the
         /// number of times specified by <paramref name="times"/>.
         /// </summary>
@@ -892,9 +928,11 @@ namespace RockLib.Logging.Moq
         /// reference to in order for successful verification to occur. Pass <see langword="null"/>
         /// if <see cref="LogEntry.Exception"/> is expected to be <see langword="null"/>.
         /// </param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -904,12 +942,12 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern, Exception exception,
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string message, Exception exception,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), null, LogLevel.Fatal, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), null, LogLevel.Fatal, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the exception specified by <paramref name="exception"/> at <see cref="LogLevel.Audit"/> the
         /// number of times specified by <paramref name="times"/>.
         /// </summary>
@@ -919,9 +957,11 @@ namespace RockLib.Logging.Moq
         /// reference to in order for successful verification to occur. Pass <see langword="null"/>
         /// if <see cref="LogEntry.Exception"/> is expected to be <see langword="null"/>.
         /// </param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -931,12 +971,12 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern, Exception exception,
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string message, Exception exception,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), null, LogLevel.Audit, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), null, LogLevel.Audit, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and the exception specified by <paramref name="exception"/> at any <see cref="LogLevel"/> the
         /// number of times specified by <paramref name="times"/>.
         /// </summary>
@@ -946,9 +986,11 @@ namespace RockLib.Logging.Moq
         /// reference to in order for successful verification to occur. Pass <see langword="null"/>
         /// if <see cref="LogEntry.Exception"/> is expected to be <see langword="null"/>.
         /// </param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="times">
         /// The number of times the mock logger is expected to have logged. If <see langword="null"/>,
@@ -958,9 +1000,9 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, Exception exception,
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string message, Exception exception,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), null, null, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), null, null, times, failMessage);
 
         /// <summary>
         /// Verifies that the mock logger logged with the exception specified by <paramref name="exception"/> and
@@ -1152,15 +1194,17 @@ namespace RockLib.Logging.Moq
             mockLogger.VerifyLog(null, ex => ReferenceEquals(ex, exception), extendedProperties, null, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// the exception specified by <paramref name="exception"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -1179,20 +1223,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern, Exception exception, object extendedProperties,
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string message, Exception exception, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Debug, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Debug, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// the exception specified by <paramref name="exception"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -1211,20 +1257,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern, Exception exception, object extendedProperties,
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string message, Exception exception, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Info, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Info, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// the exception specified by <paramref name="exception"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -1243,20 +1291,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern, Exception exception, object extendedProperties,
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string message, Exception exception, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Warn, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Warn, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// the exception specified by <paramref name="exception"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -1275,20 +1325,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern, Exception exception, object extendedProperties,
+        public static void VerifyError(this Mock<ILogger> mockLogger, string message, Exception exception, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Error, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Error, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// the exception specified by <paramref name="exception"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -1307,20 +1359,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern, Exception exception, object extendedProperties,
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string message, Exception exception, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Fatal, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Fatal, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// the exception specified by <paramref name="exception"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -1339,20 +1393,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern, Exception exception, object extendedProperties,
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string message, Exception exception, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Audit, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), extendedProperties, LogLevel.Audit, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// the exception specified by <paramref name="exception"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at any
         /// <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="exception">
         /// The exception instance that a log entry's <see cref="LogEntry.Exception"/> must be a
@@ -1371,9 +1427,9 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, Exception exception, object extendedProperties,
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string message, Exception exception, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, ex => ReferenceEquals(ex, exception), extendedProperties, null, times, failMessage);
+            mockLogger.VerifyLog(message, ex => ReferenceEquals(ex, exception), extendedProperties, null, times, failMessage);
 
         /// <summary>
         /// Verifies that the mock logger logged with an exception that returns true from the function specified
@@ -1523,14 +1579,16 @@ namespace RockLib.Logging.Moq
             mockLogger.VerifyLog(null, hasMatchingException, null, null, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and an exception that returns true from the function specified by <paramref name="hasMatchingException"/>
         /// at <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1544,19 +1602,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException,
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, null, LogLevel.Debug, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, null, LogLevel.Debug, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and an exception that returns true from the function specified by <paramref name="hasMatchingException"/>
         /// at <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1570,19 +1630,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException,
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, null, LogLevel.Info, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, null, LogLevel.Info, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and an exception that returns true from the function specified by <paramref name="hasMatchingException"/>
         /// at <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1596,19 +1658,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException,
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, null, LogLevel.Warn, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, null, LogLevel.Warn, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and an exception that returns true from the function specified by <paramref name="hasMatchingException"/>
         /// at <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1622,19 +1686,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException,
+        public static void VerifyError(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, null, LogLevel.Error, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, null, LogLevel.Error, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and an exception that returns true from the function specified by <paramref name="hasMatchingException"/>
         /// at <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1648,19 +1714,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException,
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, null, LogLevel.Fatal, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, null, LogLevel.Fatal, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and an exception that returns true from the function specified by <paramref name="hasMatchingException"/>
         /// at <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1674,19 +1742,21 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException,
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, null, LogLevel.Audit, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, null, LogLevel.Audit, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>
         /// and an exception that returns true from the function specified by <paramref name="hasMatchingException"/>
         /// at any <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1700,9 +1770,9 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException,
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, null, null, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, null, null, times, failMessage);
 
         /// <summary>
         /// Verifies that the mock logger logged with an exception that returns true from the function
@@ -1894,15 +1964,17 @@ namespace RockLib.Logging.Moq
             mockLogger.VerifyLog(null, hasMatchingException, extendedProperties, null, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// an exception that returns true from the function specified by <paramref name="hasMatchingException"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Debug"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1920,20 +1992,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyDebug(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
+        public static void VerifyDebug(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, extendedProperties, LogLevel.Debug, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, extendedProperties, LogLevel.Debug, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// an exception that returns true from the function specified by <paramref name="hasMatchingException"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Info"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1951,20 +2025,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyInfo(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
+        public static void VerifyInfo(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, extendedProperties, LogLevel.Info, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, extendedProperties, LogLevel.Info, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// an exception that returns true from the function specified by <paramref name="hasMatchingException"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Warn"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -1982,20 +2058,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyWarn(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
+        public static void VerifyWarn(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, extendedProperties, LogLevel.Warn, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, extendedProperties, LogLevel.Warn, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// an exception that returns true from the function specified by <paramref name="hasMatchingException"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Error"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -2013,20 +2091,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyError(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
+        public static void VerifyError(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, extendedProperties, LogLevel.Error, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, extendedProperties, LogLevel.Error, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// an exception that returns true from the function specified by <paramref name="hasMatchingException"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Fatal"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -2044,20 +2124,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyFatal(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
+        public static void VerifyFatal(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, extendedProperties, LogLevel.Fatal, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, extendedProperties, LogLevel.Fatal, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// an exception that returns true from the function specified by <paramref name="hasMatchingException"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at
         /// <see cref="LogLevel.Audit"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -2075,20 +2157,22 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyAudit(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
+        public static void VerifyAudit(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, extendedProperties, LogLevel.Audit, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, extendedProperties, LogLevel.Audit, times, failMessage);
 
         /// <summary>
-        /// Verifies that the mock logger logged with the message specified by <paramref name="messagePattern"/>,
+        /// Verifies that the mock logger logged with the message specified by <paramref name="message"/>,
         /// an exception that returns true from the function specified by <paramref name="hasMatchingException"/>,
         /// and the extended properties specified by <paramref name="extendedProperties"/> at any
         /// <see cref="LogLevel"/> the number of times specified by <paramref name="times"/>.
         /// </summary>
         /// <param name="mockLogger">The mock logger to verify.</param>
-        /// <param name="messagePattern">
-        /// A regular expression pattern that the message of a log must match in order for successful
-        /// verification to occur.
+        /// <param name="message">
+        /// The value that the message of a log must equal in order for successful verification
+        /// to occur. <para>If the value of this parameter starts and ends with / (forward slash),
+        /// then the contents of the value between the slashes are interpreted as a regular
+        /// expression and matched against the log message.</para>
         /// </param>
         /// <param name="hasMatchingException">
         /// A function evaluated with a log entry's <see cref="LogEntry.Exception"/> that must
@@ -2106,8 +2190,8 @@ namespace RockLib.Logging.Moq
         /// <exception cref="MockException">
         /// The logger did not log according to the specified criteria.
         /// </exception>
-        public static void VerifyLog(this Mock<ILogger> mockLogger, string messagePattern, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
+        public static void VerifyLog(this Mock<ILogger> mockLogger, string message, Expression<Func<Exception, bool>> hasMatchingException, object extendedProperties,
             Times? times = null, string failMessage = null) =>
-            mockLogger.VerifyLog(messagePattern, hasMatchingException, extendedProperties, null, times, failMessage);
+            mockLogger.VerifyLog(message, hasMatchingException, extendedProperties, null, times, failMessage);
     }
 }


### PR DESCRIPTION
Functionality had been changed in version 1.2.2, but the parameter name and doc comments weren't updated.

## Type of change: 1 (Non-functional change)

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
