### PR TITLE
Add an ILogLevelResolver; fix an issue with not disposing of a cancellationtokensource

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Extensions for verifying logging operations with Moq.
   - [Handle log provider errors](docs/LogProviderErrors.md)
   - [Use context providers](docs/ContextProviders.md)
   - [Use log processors / processing mode](docs/LogProcessors.md)
+  - [Use log level resolver](docs/LogLevelResolver.md)
   - [Format logs](docs/Formatting.md)
   - [Enable tracing for troubleshooting](docs/Tracing.md)
   - [Use LoggingTraceListener to log trace messages](docs/LoggingTraceListener.md)

--- a/RockLib.Logging/CHANGELOG.md
+++ b/RockLib.Logging/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.0 - 2022-07-01
+
+#### Changed
+
+- Adds the ability to define an `ILogLevelResolver` used to retrieve log levels at runtime.
+- Fixes a small memory leak in `RockLib.Logging.LogProcessing.BackgroundLogLevelProcessor1`
+ 
 ## 3.0.8 - 2021-08-11
 
 #### Changed

--- a/RockLib.Logging/DependencyInjection/LoggerBuilder.cs
+++ b/RockLib.Logging/DependencyInjection/LoggerBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using RockLib.Configuration;
 using RockLib.Configuration.ObjectFactory;
 using RockLib.Logging.LogProcessing;
+using RockLib.Logging.LogProviders;
 using System;
 using System.Linq;
 
@@ -109,9 +110,9 @@ namespace RockLib.Logging.DependencyInjection
             var contextProviders = options.ContextProviderRegistrations.Select(createContextProvider => createContextProvider(serviceProvider)).ToArray();
 
             if (optionsMonitor != null && options.ReloadOnChange)
-                return new ReloadingLogger(logProcessor, LoggerName, logProviders, contextProviders, optionsMonitor, options, ConfigureOptions);
+                return new ReloadingLogger(serviceProvider, logProcessor, LoggerName, logProviders, contextProviders, optionsMonitor, options, ConfigureOptions);
 
-            return new Logger(logProcessor, LoggerName, options.Level.GetValueOrDefault(),
+            return new Logger(logProcessor, LoggerName, options.Level.GetValueOrDefault(), serviceProvider.GetService<ILogLevelResolver>(),
                 logProviders, options.IsDisabled.GetValueOrDefault(), contextProviders);
         }
 

--- a/RockLib.Logging/LogProviders/ILogLevelResolver.cs
+++ b/RockLib.Logging/LogProviders/ILogLevelResolver.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RockLib.Logging.LogProviders
+{
+    /// <summary>
+    /// Used to resolve the <see cref="LogLevel"/> when logging with an <see cref="ILogger"/>
+    /// </summary>
+    public interface ILogLevelResolver
+    {
+        /// <summary>
+        /// Retrieves the currently active <see cref="LogLevel"/>
+        /// </summary>
+        /// <returns>The current <see cref="LogLevel"/></returns>
+        LogLevel GetLogLevel();
+    }
+}

--- a/RockLib.Logging/LogProviders/ILogLevelResolver.cs
+++ b/RockLib.Logging/LogProviders/ILogLevelResolver.cs
@@ -14,7 +14,9 @@ namespace RockLib.Logging.LogProviders
         /// <summary>
         /// Retrieves the currently active <see cref="LogLevel"/>
         /// </summary>
-        /// <returns>The current <see cref="LogLevel"/></returns>
-        LogLevel GetLogLevel();
+        /// <returns>The current <see cref="LogLevel"/> or null if it cannot be determined</returns>
+        /// <remarks>If the <see cref="LogLevel"/> cannot be determined, and is returned as null, then the default <see cref="LogLevel"/> 
+        /// of the <see cref="ILogger"/> will be used instead</remarks>
+        LogLevel? GetLogLevel();
     }
 }

--- a/RockLib.Logging/RockLib.Logging.csproj
+++ b/RockLib.Logging/RockLib.Logging.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Logging</PackageId>
-    <PackageVersion>3.0.8</PackageVersion>
+    <PackageVersion>3.1.0</PackageVersion>
     <Authors>RockLib</Authors>
     <Description>A simple logging library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/Tests/RockLib.Logging.Tests/DependencyInjection/LoggerBuilderTests.cs
+++ b/Tests/RockLib.Logging.Tests/DependencyInjection/LoggerBuilderTests.cs
@@ -121,10 +121,9 @@ namespace RockLib.Logging.Tests.DependencyInjection
         }
 
         [Theory(DisplayName = "Build method returns Logger instance given non-empty options")]
-        [InlineData(true), InlineData(false)]
-        public void BuildMethodHappyPath1(bool customLogLevelResolver)
+        [InlineData(true, LogLevel.Error), InlineData(false, LogLevel.Info)]
+        public void BuildMethodHappyPath1(bool customLogLevelResolver, LogLevel expectedLogLevel)
         {
-            var expectedLogLevel = customLogLevelResolver ? LogLevel.Error : LogLevel.Info;
             var services = new ServiceCollection();
 
             var logProcessor = new Mock<ILogProcessor>().Object;
@@ -159,10 +158,9 @@ namespace RockLib.Logging.Tests.DependencyInjection
         }
 
         [Theory(DisplayName = "Build method returns ReloadingLogger instance given non-empty options where ReloadOnChange is true")]
-        [InlineData(true), InlineData(false)]
-        public void BuildMethodHappyPath2(bool customLogLevelResolver)
+        [InlineData(true, LogLevel.Error), InlineData(false, LogLevel.Info)]
+        public void BuildMethodHappyPath2(bool customLogLevelResolver, LogLevel expectedLogLevel)
         {
-            var expectedLogLevel = customLogLevelResolver ? LogLevel.Error : LogLevel.Info;
             var services = new ServiceCollection();
 
             var logProcessor = new Mock<ILogProcessor>().Object;
@@ -200,10 +198,9 @@ namespace RockLib.Logging.Tests.DependencyInjection
         }
 
         [Theory(DisplayName = "Build method returns logger created from configuration given empty options")]
-        [InlineData(true), InlineData(false)]
-        public void BuildMethodHappyPath3(bool customLogLevelResolver)
+        [InlineData(true, LogLevel.Error), InlineData(false, LogLevel.Warn)]
+        public void BuildMethodHappyPath3(bool customLogLevelResolver, LogLevel expectedLogLevel)
         {
-            var expectedLogLevel = customLogLevelResolver ? LogLevel.Error : LogLevel.Warn;
             var services = new ServiceCollection();
 
             var logProcessor = new Mock<ILogProcessor>().Object;

--- a/Tests/RockLib.Logging.Tests/DependencyInjection/LoggerBuilderTests.cs
+++ b/Tests/RockLib.Logging.Tests/DependencyInjection/LoggerBuilderTests.cs
@@ -124,6 +124,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
         [InlineData(true), InlineData(false)]
         public void BuildMethodHappyPath1(bool customLogLevelResolver)
         {
+            var expectedLogLevel = customLogLevelResolver ? LogLevel.Error : LogLevel.Info;
             var services = new ServiceCollection();
 
             var logProcessor = new Mock<ILogProcessor>().Object;
@@ -150,7 +151,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
 
             logger.Should().BeOfType<Logger>()
                 .Which.LogProcessor.Should().BeSameAs(logProcessor);
-            logger.Level.Should().Be(customLogLevelResolver ? LogLevel.Error : LogLevel.Info);
+            logger.Level.Should().Be(expectedLogLevel);
             logger.LogProviders.Should().ContainSingle()
                 .Which.Should().BeSameAs(logProvider);
             logger.ContextProviders.Should().ContainSingle()
@@ -161,6 +162,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
         [InlineData(true), InlineData(false)]
         public void BuildMethodHappyPath2(bool customLogLevelResolver)
         {
+            var expectedLogLevel = customLogLevelResolver ? LogLevel.Error : LogLevel.Info;
             var services = new ServiceCollection();
 
             var logProcessor = new Mock<ILogProcessor>().Object;
@@ -190,7 +192,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
             var logger = builder.Build(serviceProvider);
 
             logger.Should().BeOfType(ReloadingLoggerTests.ReloadingLogger);
-            logger.Level.Should().Be(customLogLevelResolver ? LogLevel.Error : LogLevel.Info);
+            logger.Level.Should().Be(expectedLogLevel);
             logger.LogProviders.Should().ContainSingle()
                 .Which.Should().BeSameAs(logProvider);
             logger.ContextProviders.Should().ContainSingle()
@@ -201,6 +203,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
         [InlineData(true), InlineData(false)]
         public void BuildMethodHappyPath3(bool customLogLevelResolver)
         {
+            var expectedLogLevel = customLogLevelResolver ? LogLevel.Error : LogLevel.Warn;
             var services = new ServiceCollection();
 
             var logProcessor = new Mock<ILogProcessor>().Object;
@@ -231,7 +234,7 @@ namespace RockLib.Logging.Tests.DependencyInjection
 
             logger.Should().BeOfType<Logger>()
                 .Which.LogProcessor.Should().BeSameAs(logProcessor);
-            logger.Level.Should().Be(customLogLevelResolver ? LogLevel.Error : LogLevel.Warn);
+            logger.Level.Should().Be(expectedLogLevel);
             logger.LogProviders.Should().ContainSingle()
                 .Which.Should().BeOfType<ConsoleLogProvider>()
                 .Which.Formatter.Should().BeOfType<TemplateLogFormatter>()

--- a/Tests/RockLib.Logging.Tests/LoggerTests.cs
+++ b/Tests/RockLib.Logging.Tests/LoggerTests.cs
@@ -1,7 +1,9 @@
 ﻿using FluentAssertions;
 using Moq;
 using RockLib.Logging.LogProcessing;
+using RockLib.Logging.LogProviders;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace RockLib.Logging.Tests
@@ -170,6 +172,38 @@ namespace RockLib.Logging.Tests
             logger.Log(logEntry);
 
             logEntry.CallerInfo.Should().NotBeNullOrWhiteSpace();
+        }
+
+        public static IEnumerable<object[]> LogLevelResolverProvider_TestsCases
+        {
+            get
+            {
+                foreach (LogLevel level in Enum.GetValues(typeof(LogLevel)))
+                {
+                    yield return new object[] { level };
+                }
+
+                yield return new object[] { null };
+            }
+        }
+        [Theory, MemberData(nameof(LogLevelResolverProvider_TestsCases))]
+        public void LogLevelResolverProvider(LogLevel? expected)
+        {
+            var logLevelResolver = new Mock<ILogLevelResolver>();
+            logLevelResolver.Setup(i => i.GetLogLevel()).Returns(expected);
+
+            var logger = new Logger(level: LogLevel.Warn, logLevelResolver: logLevelResolver.Object);
+
+            LogLevel actual = logger.Level;
+
+            if (expected != null)
+            {
+                actual.Should().Be(expected);
+            }
+            else
+            {
+                actual.Should().Be(LogLevel.Warn);
+            }
         }
     }
 }

--- a/docs/LogLevelResolver.md
+++ b/docs/LogLevelResolver.md
@@ -1,0 +1,19 @@
+# Log Level Resolvers
+
+The `ILogLevelResolver` interface defines a custom method in which any given `ILogger` can use to retrieve it's `LogLevel` on-demand.
+
+**Note:** `ILogLevelResolver` does not affect the logging level for other default loggers (such as `Microsoft.Extensions.Logging.ILogger`). It will only affect logs routed through `RockLib.Logging.ILogger`.
+
+## Creating Your Own Resolver
+
+New log level resolvers can be created by implementing the `ILogLevelResolver` interface, and registering the implementation to the DI container. If no DI container is used, you may pass `ILogLevelResolver` directly into the constructor of a `Logger`. 
+
+Only one `ILogLevelResolver` may be used per application when DI is used.
+
+### Implementation
+
+The interface `ILogLevelResolver` contains one method - `GetLogLevel()`. This method can return a `LogLevel`, or `null`. When a `LogLevel` is returned, that `LogLevel` will be used for all messages. When `null` is returned, the `ILogger` will fall back to it's primary method of obtaining the logging level (e.g. via an `appsettings.json` configuration).
+
+## Use Cases
+
+This interface can be useful if you would like your application to be able to switch logging levels at runtime. When adding a custom `ILogLevelResolver`, the implementation itself can be setup to pull log levels from wherever you would like.


### PR DESCRIPTION
## Description
This PR adds the ability to define a custom resolver for how the `LogLevel` is retrieved for all `ILogger` instances.  For example, when deploying applications in production to cloud hosted providers, you may have a need to increase/decrease the logging level at runtime on demand. Under normal circumstances, the only way to do this would be to do one of the following:

1. Redeploy the application with a new value for the `LogLevel` in the settings file
2. Add some custom code to manually find and update the settings file at runtime, and also ensure that the logger is set to reload
3. SSH-in (or something comparable) and manually update the settings file

Every one of these solutions is not great.  The best one is updating the settings file at runtime, but that solution introduces so much unneeded complexity when talking about real use-cases (what about lambdas? how often do you check? could implementations break between windows/linux? etc.)

A much simpler solution would be to allow consumers of RockLib.Logging to define their own method for retrieving the `LogLevel` when it's requested.

For a use-case, let's pretend that you have an application that is deployed to production, and you use something such as Split.IO, VWO, Flagship.IO... i don't know.. just some solution that provides you with a method for defining production behavior at runtime.  If your production application is experiencing problems, and you need on-demand, detailed logging, what do you do? 
**Do you redeploy?** No, that would be timely and deploying is a can of worms. **Do you SSH in?** To prod? No. **Do you implement custom code to update an appsettings.json file?** I suppose that would be the only alternative.

So now, what you can do is just implement an instance of `ILogLevelResolver` and register it to your DI container. It will automatically get populated into the `ILogger`, and the method `GetLogLevel` can be implemented however you would like. If you want to retrieve the log level from some attribute management application, go for it. If you want to use an internal endpoint to manually set the log level whenever you want.. you can do that to.  The best part is that, from the perspective of RockLib.Logging, there is little to manage - the consumer should be implementing the contract correctly.. if they don't, that is on them.

## Type of change: <!-- Choose the highest number that applies -->
3. New feature (non-breaking change that adds functionality)

## Checklist:
- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
