### PR TITLE
Add thread ID as default log entry property

### DIFF
--- a/RockLib.Logging/LogEntry.cs
+++ b/RockLib.Logging/LogEntry.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 
 namespace RockLib.Logging
 {
@@ -177,6 +178,8 @@ namespace RockLib.Logging
         /// </param>
         public void SetExtendedProperties(object extendedProperties)
         {
+            ExtendedProperties["ThreadID"] = Thread.CurrentThread.ManagedThreadId;
+
             if (extendedProperties == null)
                 return;
             if (extendedProperties is IEnumerable<KeyValuePair<string, object>> stringDictionary)


### PR DESCRIPTION
## Description

#109 
Having the ThreadID as a default extended property on the log entry would be helpful and I don't think it would ever hurt anything.

I thought about where this addition could go - the log processor makes sense, but if a background processor is in place, the value won't be accurate. I also thought it could go on the `Logger` instance, but then custom implementations may not inherit this nicety.

Am curious on feedback or opinions on this type of addition.

## Type of change: <!-- Choose the highest number that applies -->

3. New feature (non-breaking change that adds functionality)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
