### PR TITLE
pass spanId and traceId into the logEntry

### DIFF
--- a/RockLib.Logging.AspNetCore/CorrelationIdContextProvider.cs
+++ b/RockLib.Logging.AspNetCore/CorrelationIdContextProvider.cs
@@ -46,8 +46,8 @@ public class CorrelationIdContextProvider : IContextProvider
         {
             logEntry.CorrelationId ??= Accessor.CorrelationId;
             // Otel alignment for aligning logs w/metrics & traces
-            logEntry.ExtendedProperties.Add("TraceId", Accessor.GetTraceId());
-            logEntry.ExtendedProperties.Add("SpanId", Accessor.GetSpanId());
+            logEntry.ExtendedProperties.Add("TraceId", Accessor.TraceId);
+            logEntry.ExtendedProperties.Add("SpanId", Accessor.SpanId);
         }
     }
 }

--- a/RockLib.Logging.AspNetCore/CorrelationIdContextProvider.cs
+++ b/RockLib.Logging.AspNetCore/CorrelationIdContextProvider.cs
@@ -41,6 +41,13 @@ public class CorrelationIdContextProvider : IContextProvider
     public void AddContext(LogEntry logEntry)
     {
         if (logEntry is null) { throw new ArgumentNullException(nameof(logEntry)); }
-        logEntry.CorrelationId ??= Accessor?.CorrelationId;
+
+        if (Accessor is not null)
+        {
+            logEntry.CorrelationId ??= Accessor.CorrelationId;
+            // Otel alignment for aligning logs w/metrics & traces
+            logEntry.ExtendedProperties.Add("TraceId", Accessor.GetTraceId());
+            logEntry.ExtendedProperties.Add("SpanId", Accessor.GetSpanId());
+        }
     }
 }

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -23,7 +23,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-		<PackageReference Include="RockLib.DistributedTracing.AspNetCore" Version="2.1.0-alpha.1" />
+		<PackageReference Include="RockLib.DistributedTracing.AspNetCore" Version="2.1.0" />
 		<PackageReference Include="RockLib.Logging" Version="4.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
 		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -23,7 +23,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-		<PackageReference Include="RockLib.DistributedTracing.AspNetCore" Version="2.0.0" />
+		<PackageReference Include="RockLib.DistributedTracing.AspNetCore" Version="2.1.0-alpha.1" />
 		<PackageReference Include="RockLib.Logging" Version="4.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
 		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />

--- a/Tests/RockLib.Logging.AspNetCore.Tests/ContextProviderTests.cs
+++ b/Tests/RockLib.Logging.AspNetCore.Tests/ContextProviderTests.cs
@@ -71,6 +71,21 @@ public class ContextProviderTests
         logEntry.CorrelationId.Should().Be(correlationId);
     }
 
+    [Fact(DisplayName = "CorrelationIdContextProvider.TraceId is empty and not added to the LogEntry")]
+    public void CorrelationIdContextProviderNoTraceId()
+    {
+        var idAccessorMock = new Mock<ICorrelationIdAccessor>();
+
+        var contextProvider = new CorrelationIdContextProvider(idAccessorMock.Object);
+        Assert.Null(contextProvider.Accessor?.TraceId);
+        Assert.Null(contextProvider.Accessor?.SpanId);
+        var logEntry = new LogEntry();
+
+        contextProvider.AddContext(logEntry);
+        logEntry.ExtendedProperties["TraceId"].Should().BeNull(); 
+        logEntry.ExtendedProperties["SpanId"].Should().BeNull();
+    }
+
     [Fact(DisplayName = "ForwardedForContextProvider uses IHttpContextAccessor correctly")]
     public void ForwardedForContextProviderConstructor1()
     {


### PR DESCRIPTION
## Description

1. Rev DistributedTracing library to the one aligned with Open Telemetry.
2. Inject SpanId and TraceId into log entries (if present).
3. Update unit test accordingly.

## Type of change:

3. New feature (non-breaking change that adds functionality)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
yes
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
yes
- Have you added tests that prove your fix is effective or that this feature works?
yes
- New and existing unit tests pass locally with these changes?
yes
- Have you made corresponding changes to the documentation?
N/A
- Will this change require an update to an example project? (if so, create an issue and link to it)
no

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
