### PR TITLE
RockLib.Logging.AspNetCore Release 4.0.0-alpha.1

### DIFF
--- a/RockLib.Logging.AspNetCore/CHANGELOG.md
+++ b/RockLib.Logging.AspNetCore/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 4.0.0-alpha.1 - Not yet released
-	
+## 4.0.0-alpha.1 - 2022-10-20
+
 #### Added
+- Injected TraceId and SpanId into ExtendedProperties for the LogEntry.
 - Added `.editorconfig` and `Directory.Build.props` files to ensure consistency.
 
 #### Changed
+- Updated DistributedTracing dependency to new version using OpenTelemetry TraceId and SpanId.
 - Supported targets: net6.0, netcoreapp3.1, and net48.
 - As the package now uses nullable reference types, some method parameters now specify if they can accept nullable values.
 - The `LoggingActionFilter` class has been renamed to `LoggingActionFilterAttribute` to follow .NET naming conventions.


### PR DESCRIPTION
## Description

This releases RockLib.Logging.AspNetCore 4.0.0-alpha.1.

Note that we had existing changes that were never released as 4.0.0-alpha.1 so I'm just re-using that version number since it was never published to nuget.
---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
