### PR TITLE
Distributed tracing

### DIFF
--- a/RockLib.Logging/LogEntry.cs
+++ b/RockLib.Logging/LogEntry.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -178,6 +179,13 @@ public sealed class LogEntry
     /// </param>
     public void SetExtendedProperties(object? extendedProperties)
     {
+#if NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER
+        if (Activity.Current != null)
+        {
+            ExtendedProperties["SpanId"] = Activity.Current.SpanId.ToHexString();
+            ExtendedProperties["TraceId"] = Activity.Current.TraceId.ToHexString();
+        }
+#endif
         if (extendedProperties is null)
         {
             return;


### PR DESCRIPTION
## Description
Adding functionality to check the [current activities](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-7.0) trace id and span id and appending it to the log entries extended properties.  This will allow the log to be tied to a distributed trace furthering the applications observability. 

## Type of change: <!-- Choose the highest number that applies -->
New feature (non-breaking change that adds functionality)

