### PR TITLE
Removed .NET 6 From Dependent Packages

### DIFF
--- a/RockLib.Logging.AspNetCore/CHANGELOG.md
+++ b/RockLib.Logging.AspNetCore/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.0.0-alpha.1 - 2025-01-30
+
+#### Changed
+- Removed .NET 6 as a target framework
+- Updated the following package references
+	- RockLib.Logging - 6.0.0-alpha.1
+	- RockLib.DistributedTracing.AspNetCore - 4.0.0
+	- Microsoft.AspNetCore.Mvc.Core - 2.3.0
+	- Microsoft.AspNetCore.Routing - 2.3.0
+
 ## 5.1.2 - 2024-10-22
 
 #### Changed

--- a/RockLib.Logging.AspNetCore/CHANGELOG.md
+++ b/RockLib.Logging.AspNetCore/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the following package references
 	- RockLib.Logging - 6.0.0-alpha.1
 	- RockLib.DistributedTracing.AspNetCore - 4.0.0
-	- Microsoft.AspNetCore.Mvc.Core - 2.3.0
-	- Microsoft.AspNetCore.Routing - 2.3.0
 
 ## 5.1.2 - 2024-10-22
 

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -27,8 +27,8 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RockLib.DistributedTracing.AspNetCore" Version="4.0.0" />
 		<PackageReference Include="RockLib.Logging" Version="6.0.0-alpha.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\LICENSE.md" Pack="true" PackagePath="" />

--- a/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
+++ b/RockLib.Logging.AspNetCore/RockLib.Logging.AspNetCore.csproj
@@ -12,9 +12,9 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Logging/blob/main/RockLib.Logging.AspNetCore/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageTags>RockLib Logging Logger AspNetCore HttpContext ActionFilter</PackageTags>
-		<PackageVersion>5.1.2</PackageVersion>
+		<PackageVersion>6.0.0-alpha.1</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>5.1.2</Version>
+		<Version>6.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -25,10 +25,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="RockLib.DistributedTracing.AspNetCore" Version="3.0.0" />
-		<PackageReference Include="RockLib.Logging" Version="5.1.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />
+		<PackageReference Include="RockLib.DistributedTracing.AspNetCore" Version="4.0.0" />
+		<PackageReference Include="RockLib.Logging" Version="6.0.0-alpha.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\LICENSE.md" Pack="true" PackagePath="" />

--- a/RockLib.Logging.Microsoft.Extensions/CHANGELOG.md
+++ b/RockLib.Logging.Microsoft.Extensions/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0-alpha.1 - 2025-01-30
+
+#### Changed
+- Removed .NET 6 as a target framework
+- Updated the following package references
+	- RockLib.Logging - 6.0.0-alpha.1
+
 ## 3.1.2 - 2024-10-22
 
 #### Changed

--- a/RockLib.Logging.Microsoft.Extensions/RockLib.Logging.Microsoft.Extensions.csproj
+++ b/RockLib.Logging.Microsoft.Extensions/RockLib.Logging.Microsoft.Extensions.csproj
@@ -11,10 +11,10 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Logging/blob/main/RockLib.Logging.Microsoft.Extensions/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>RockLib Logging Logger Microsoft Extensions</PackageTags>
-		<PackageVersion>3.1.2</PackageVersion>
+		<PackageVersion>4.0.0-alpha.1</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<RootNamespace>RockLib.Logging</RootNamespace>
-		<Version>3.1.2</Version>
+		<Version>4.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -27,7 +27,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-		<PackageReference Include="RockLib.Logging" Version="5.1.2" />
+		<PackageReference Include="RockLib.Logging" Version="6.0.0-alpha.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\LICENSE.md" Pack="true" PackagePath="" />

--- a/RockLib.Logging.Moq/CHANGELOG.md
+++ b/RockLib.Logging.Moq/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0-alpha.1 - 2025-01-30
+
+#### Changed
+- Removed .NET 6 as a target framework
+- Updated the following package references
+	- RockLib.Logging - 6.0.0-alpha.1
+
 ## 3.1.2 - 2024-10-22
 
 #### Changed

--- a/RockLib.Logging.Moq/RockLib.Logging.Moq.csproj
+++ b/RockLib.Logging.Moq/RockLib.Logging.Moq.csproj
@@ -10,10 +10,10 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Logging/blob/main/RockLib.Logging.Moq/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>RockLib Logging Logger Extensions Moq</PackageTags>
-		<PackageVersion>3.1.2</PackageVersion>
+		<PackageVersion>4.0.0-alpha.1</PackageVersion>
 		<PackageIcon>icon.png</PackageIcon>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.1.2</Version>
+		<Version>4.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="RockLib.Logging" Version="5.1.2" />
+		<PackageReference Include="RockLib.Logging" Version="6.0.0-alpha.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\LICENSE.md" Pack="true" PackagePath="" />

--- a/Tests/RockLib.Logging.AspNetCore.Tests/RockLib.Logging.AspNetCore.Tests.csproj
+++ b/Tests/RockLib.Logging.AspNetCore.Tests/RockLib.Logging.AspNetCore.Tests.csproj
@@ -7,10 +7,10 @@
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="RockLib.Logging.Moq" Version="3.1.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="RockLib.Logging.Moq" Version="3.1.2" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Logging.Microsoft.Extensions.Tests/RockLib.Logging.Microsoft.Extensions.Tests.csproj
+++ b/Tests/RockLib.Logging.Microsoft.Extensions.Tests/RockLib.Logging.Microsoft.Extensions.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="RockLib.Logging.Moq" Version="3.1.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="RockLib.Logging.Moq" Version="3.1.2" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Logging.Moq.Tests/RockLib.Logging.Moq.Tests.csproj
+++ b/Tests/RockLib.Logging.Moq.Tests/RockLib.Logging.Moq.Tests.csproj
@@ -4,13 +4,13 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Type of change: 

4. Breaking change (fix or feature that could cause existing functionality to not work as expected)
